### PR TITLE
Enable theme-based fonts

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,6 +47,10 @@
     --crt-vignette: radial-gradient(circle at center, transparent 60%, rgba(0, 0, 0, 0.6) 100%);
     --crt-interlace-color: rgba(0, 0, 0, 0.25);
     --font-family: 'Press Start 2P', monospace;
+    --button-font-size: 24px;
+    --upgrade-button-font-size: 16px;
+    --hud-font-size: 19px;
+    --hotkey-font-size: 14px;
 }
 /* Font served from Google Fonts */
 *{font-family: var(--font-family); box-sizing:border-box;margin:0;padding:0}
@@ -54,7 +58,7 @@ body{margin:0;overflow:hidden;background: var(--body-bg); color: var(--text-colo
 #crt-overlay{position:fixed;top:0;left:0;width:100vw;height:100vh;pointer-events:none;z-index:9999;background-image: var(--crt-overlay-bg); background-size:100% 2px;background-blend-mode: var(--crt-overlay-blend)}
 #gameCanvas{background: var(--canvas-bg); position:absolute;top:0;left:0} /* Renamed from #g */
 .bg{position:absolute;top:0;left:0;width:100%;height:100%;background: var(--bg-gradient); z-index:-1}
-#hud{position:absolute;top:0;left:10px;right:10px;display:flex;justify-content:space-between;align-items:center;font-size:19px;padding:0;z-index:10;line-height:2;min-height:0; color: var(--hud-color)} /* Renamed from #u */
+#hud{position:absolute;top:0;left:10px;right:10px;display:flex;justify-content:space-between;align-items:center;font-size:var(--hud-font-size);padding:0;z-index:10;line-height:2;min-height:0; color: var(--hud-color)} /* Renamed from #u */
 #startScreen h1,#gameOverScreen h1{font-size:2rem;text-align:center;white-space:nowrap;overflow:hidden;text-overflow:ellipsis; color: var(--title-color)} /* Renamed from #s, #o */
 #gameOverScreen h1{font-size:3.5rem;margin-bottom:1rem} /* Renamed from #o */
 #hud span{flex:1;text-align:center;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
@@ -63,13 +67,13 @@ body{margin:0;overflow:hidden;background: var(--body-bg); color: var(--text-colo
 #startScreen,#gameOverScreen,#upgradeMenu,#highScoreScreen,#highScoreModal{position:absolute;top:0;left:0;right:0;bottom:0;display:flex;flex-direction:column;justify-content:center;align-items:center;background:rgba(0,0,0,0.8);text-align:center;z-index:100} /* Renamed from #s, #o, #m */
 #gameOverScreen #finalStats{font-size:1.33rem;margin-bottom:1.5rem;color: var(--final-stats-color)} /* Renamed from #f */
 #upgradeMenu{position:absolute;top:0;left:0;bottom:0;width: 450px; display:flex;flex-direction:column;justify-content:flex-start;align-items: flex-start; padding-top:20px;overflow-y:auto; background:rgba(0,0,0,0.8);z-index:100} /* Modified to position on the left */
-button{padding:10px 20px;font-size:24px;line-height:1;margin-top:22px;background: var(--button-bg); color: var(--button-text); border:2px solid var(--button-border); cursor:pointer;transition:all 0.3s ease}
+button{padding:10px 20px;font-size:var(--button-font-size);line-height:1;margin-top:22px;background: var(--button-bg); color: var(--button-text); border:2px solid var(--button-border); cursor:pointer;transition:all 0.3s ease}
 button:hover{background: var(--button-hover-bg); transform:translateY(-2px);box-shadow:0 4px 8px rgba(0,0,0,0.2)}
 button:active{transform:translateY(1px)}
 button:disabled{background: var(--button-disabled-bg); color: var(--button-disabled-text); cursor:not-allowed;transform:none;box-shadow:none}
 .upgrade-category h3{text-align:left;margin-bottom:2px;color: var(--upgrade-title-color);cursor:pointer}
 .upgrade-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:10px}
-.upgrade-button-container button{font-size:16px;white-space:normal;word-wrap:break-word}
+.upgrade-button-container button{font-size:var(--upgrade-button-font-size);white-space:normal;word-wrap:break-word}
 #focus-notch-container{display:flex;flex-direction:column;align-items:center;margin-top:5px}
 #focus-notch-row{display:flex;gap:2px;margin-top:4px}
 .focus-notch{width:10px;height:16px;border:1px solid var(--button-border);background:#111;cursor:pointer;box-shadow:0 0 2px var(--button-border) inset;border-radius:0}
@@ -91,7 +95,7 @@ input:checked+.slider:before{transform:translateX(26px)}
 .switch-label{color: var(--switch-label-color); font-size:16px}
 .stats{display:flex;justify-content:center;gap:20px;margin-top:10px}
 .stats div{border:1px solid var(--stats-border); padding:5px 10px;background: var(--stats-bg); border-radius:5px}
-#hotkeys{position:absolute;top:60px;right:10px;background: var(--hotkey-bg); padding:5px 10px;border-radius:5px;font-size:14px;color: var(--hotkey-text); display:none}
+#hotkeys{position:absolute;top:60px;right:10px;background: var(--hotkey-bg); padding:5px 10px;border-radius:5px;font-size:var(--hotkey-font-size);color: var(--hotkey-text); display:none}
 #hotkeys.show{display:block}
 /* Removed styles related to DOM-based ring UI (.ring-upgrade-box, .upgrade-info-panel, .ring-info-container, etc.) */
 #highScoreTable table{width:80%;margin:0 auto;border-collapse:collapse}
@@ -107,7 +111,7 @@ input:checked+.slider:before{transform:translateX(26px)}
 .crt-container::before{content:'';position:absolute;top:0;left:0;width:100%;height:100%;background: var(--crt-vignette); pointer-events:none;z-index:1}
 .crt-container::after{content:'';position:absolute;top:0;left:0;width:100%;height:100%;background:linear-gradient(rgba(18,16,16,0) 50%, var(--crt-interlace-color) 50%);background-size:100% 4px;pointer-events:none;z-index:2}
 </style>
-<link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&family=VT323&family=Share+Tech+Mono&display=swap" rel="stylesheet">
 </head>
 <body>
 <div class="bg"></div>
@@ -214,7 +218,16 @@ const THEMES = [
             '--crt-scanline-color': 'rgba(0, 0, 0, 0.1)',
             '--crt-vignette': 'radial-gradient(circle at center, transparent 60%, rgba(0, 0, 0, 0.6) 100%)',
             '--crt-interlace-color': 'rgba(0, 0, 0, 0.25)',
-            '--font-family': "'Press Start 2P', monospace"
+            '--font-family': "'Press Start 2P', monospace",
+            '--button-font-size': '24px',
+            '--upgrade-button-font-size': '16px',
+            '--hud-font-size': '19px',
+            '--hotkey-font-size': '14px'
+        },
+        fontSizes: {
+            tab: 14,
+            upgrade: 12,
+            ringUI: 11
         },
         canvasColors: {
             base: 'rgb(94, 79, 162)',
@@ -297,7 +310,16 @@ const THEMES = [
             '--crt-scanline-color': 'rgba(0, 255, 0, 0.1)',
             '--crt-vignette': 'radial-gradient(circle at center, transparent 60%, rgba(0, 40, 0, 0.6) 100%)',
             '--crt-interlace-color': 'rgba(0, 255, 0, 0.25)',
-            '--font-family': "'Press Start 2P', monospace"
+            '--font-family': "'VT323', monospace",
+            '--button-font-size': '22px',
+            '--upgrade-button-font-size': '15px',
+            '--hud-font-size': '18px',
+            '--hotkey-font-size': '13px'
+        },
+        fontSizes: {
+            tab: 14,
+            upgrade: 11,
+            ringUI: 10
         },
         canvasColors: {
             base: '#00ffcc',
@@ -378,7 +400,16 @@ const THEMES = [
             '--crt-scanline-color': 'rgba(0, 0, 0, 0.1)',
             '--crt-vignette': 'radial-gradient(circle at center, transparent 60%, rgba(255, 255, 255, 0.6) 100%)',
             '--crt-interlace-color': 'rgba(0, 0, 0, 0.25)',
-            '--font-family': "'Press Start 2P', cursive"
+            '--font-family': "'Share Tech Mono', monospace",
+            '--button-font-size': '20px',
+            '--upgrade-button-font-size': '14px',
+            '--hud-font-size': '18px',
+            '--hotkey-font-size': '12px'
+        },
+        fontSizes: {
+            tab: 13,
+            upgrade: 10,
+            ringUI: 9
         },
         canvasColors: {
             base: '#333333',
@@ -1941,7 +1972,8 @@ function drawGame() {
 
         // Draw tab text
         ctx.fillStyle = currentTheme.canvasColors.ringUpgradeBoxText || 'rgba(230, 181, 75, 1)';
-        ctx.font = `14px ${currentTheme.cssVariables['--font-family'] || "'Press Start 2P', monospace"}`;
+        const tabFont = currentTheme.fontSizes?.tab || 14;
+        ctx.font = `${tabFont}px ${currentTheme.cssVariables['--font-family'] || "'Press Start 2P', monospace"}`;
         ctx.textAlign = 'center';
         ctx.textBaseline = 'middle';
         ctx.fillText(category.category, tabX + tabDisplayWidth / 2, tabY + tabDisplayHeight / 2);
@@ -1989,7 +2021,8 @@ function drawGame() {
 
             // Draw button text
             ctx.fillStyle = canUpgrade ? (currentTheme.canvasColors.ringUpgradeBoxText || 'rgba(230, 181, 75, 1)') : (currentTheme.canvasColors.buttonDisabledText || '#ac4834');
-            ctx.font = `12px ${currentTheme.cssVariables['--font-family'] || "'Press Start 2P', monospace"}`;
+            const upgradeFont = currentTheme.fontSizes?.upgrade || 12;
+            ctx.font = `${upgradeFont}px ${currentTheme.cssVariables['--font-family'] || "'Press Start 2P', monospace"}`;
             ctx.textAlign = 'left';
             ctx.textBaseline = 'top';
 
@@ -2264,7 +2297,7 @@ function drawRingUIElement(type, radius, labelText, categoryIndex, upgradeIndex,
 
     const elementBaseX = radius; // Position along the rotated x-axis
     const elementBaseY = 0;
-    const fontSize = 11;
+    const fontSize = currentTheme.fontSizes?.ringUI || 11;
     const padding = 3;
     const boxSize = 8;
     const boxSpacing = 2;
@@ -2380,7 +2413,7 @@ function drawRingUIElement(type, radius, labelText, categoryIndex, upgradeIndex,
 // --- Canvas Collapsible Upgrade Category UI Drawing Helper ---
 // Modified to handle a whole category of upgrades
 function drawCollapsibleUpgradeElement(x, y, title, category, categoryIndex, isExpanded, color) {
-    const fontSize = 12;
+    const fontSize = currentTheme.fontSizes?.upgrade || 12;
     const padding = 8;
     const boxMargin = 4;
     const upgradeSpacing = 10; // Space between upgrades


### PR DESCRIPTION
## Summary
- allow themes to set button, upgrade, HUD and hotkey font sizes via CSS variables
- let themes specify canvas text sizes
- add Google font link for additional fonts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ac5db48b88322a1877037c2a07a2e