### PR TITLE
Fix upgrade category toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -2733,7 +2733,7 @@ function renderUpgradeMenu() {
     upgradeTree.forEach((category, i) => {
         upgradeHTML += `
         <div class="upgrade-category">
-            <h3 onclick="toggleUpgradeCategory(${i})">${category.category}</h3>
+            <h3 onclick="toggleUpgradeCategory(${i})">${category.expanded ? '&#9662;' : '&#9656;'} ${category.category}</h3>
             <div id="upgrade-grid-${i}" class="upgrade-grid" style="display:${category.expanded ? 'grid' : 'none'}">
         `;
         if (category.expanded) {
@@ -3293,6 +3293,7 @@ window.onload = () => {
 
 // --- Global Access (for HTML onclick) ---
 window.purchaseUpgrade = purchaseUpgrade; // Make purchase function global for button clicks
+window.toggleUpgradeCategory = toggleUpgradeCategory; // Expose category toggling
 
 
 })(); // End IIFE


### PR DESCRIPTION
## Summary
- expose `toggleUpgradeCategory` so clicking upgrade headers collapses/expands categories

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ba19a083c8322acb3af036dbe82a4