### PR TITLE
Enable online leaderboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,8 @@
 <!-- V2.9: Major refactor - Canvas Ring UI, Descriptive Names, Constants, Update Loop Split -->
 <!-- Added Phaser library -->
 <script src="https://cdn.jsdelivr.net/npm/phaser@3.60.0/dist/phaser.min.js"></script>
+<script src="https://www.gstatic.com/firebasejs/10.12.0/firebase-app.js"></script>
+<script src="https://www.gstatic.com/firebasejs/10.12.0/firebase-database.js"></script>
 <title>Orbital Defence Elite v2.34 - Optimised</title>
 <link rel="icon" type="image/x-icon" href="favicon.ico">
 <style>
@@ -118,10 +120,13 @@ input:checked+.slider:before{transform:translateX(26px)}
     <button id="loadButton" style="display:none;">Load Game</button> <!-- Added Load Button -->
     <button id="highScoreButton">High Scores</button>
 </div>
-<div id="gameOverScreen" style="display:none"> <!-- Renamed from #o -->
+<div id="gameOverScreen" style="display:none">
     <h1>Game Over</h1>
-    <div id="finalStats"></div> <!-- Renamed from #f -->
-    <div id="gameOverHighScores"></div>
+    <div id="finalStats"></div>
+    <h2>Local Top 10</h2>
+    <div id="localHighScores"></div>
+    <h2>Global Top 10 <label style="font-size:14px"><input type="checkbox" id="enableOnlineLeaderboard"> Enable Online Leaderboard</label></h2>
+    <div id="globalHighScores"></div>
     <div id="nonHighScoreMessage" style="margin-top:10px"></div>
     <button id="restartButton">Play Again</button> <!-- Renamed from #r -->
 </div>
@@ -432,6 +437,18 @@ const THEMES = [
 ];
 </script>
 <script>
+const firebaseConfig = {
+  apiKey: "AIzaSyA5CSbcR_DS601s5Ok_f-UOT_dobysD9eU",
+  authDomain: "lb-1file.firebaseapp.com",
+  projectId: "lb-1file",
+  storageBucket: "lb-1file.firebasestorage.app",
+  messagingSenderId: "828776232983",
+  appId: "1:828776232983:web:6a93c19468c9c70124c452",
+  measurementId: "G-0279TD72PL"
+};
+firebase.initializeApp(firebaseConfig);
+const db = firebase.database();
+</script>
 (function(){ // IIFE to encapsulate code
 "use strict";
 let currentThemeIndex = 0;
@@ -1085,7 +1102,7 @@ function recordHighScore(score) {
         showHighScoreModal(score, beaten);
     } else {
         getElement('nonHighScoreMessage').textContent = `Game Over – You placed #${rank}. Try again to reach the top 10!`;
-        renderHighScores('gameOverHighScores', scores);
+        renderHighScores('localHighScores', scores);
     }
 }
 
@@ -1106,7 +1123,7 @@ function saveHighScoreFromModal() {
     scores.sort((a,b) => b.score - a.score);
     scores = scores.slice(0,10);
     saveHighScores(scores);
-    renderHighScores('gameOverHighScores', scores);
+    renderHighScores('localHighScores', scores);
     getElement('highScoreModal').style.display = 'none';
     getElement('nonHighScoreMessage').textContent = '';
     pendingHighScore = null;
@@ -1147,6 +1164,54 @@ function closeHighScoreScreen() {
 }
 
 // --- Game Initialization & Start ---
+async function fetchGlobalScores(){
+    try {
+        const snap = await db.ref("scores").once("value");
+        let arr = snap.val() || [];
+        if(!Array.isArray(arr)) arr = [];
+        arr.sort((a,b)=>b.score-a.score);
+        renderHighScores("globalHighScores", arr);
+        return arr;
+    } catch(e){
+        console.error("Failed to fetch global scores", e);
+        getElement("globalHighScores").innerHTML = "<p>Could not connect to server</p>";
+        return [];
+    }
+}
+
+async function submitGlobalScore(initials, country, score){
+    try {
+        const snap = await db.ref("scores").once("value");
+        let arr = snap.val() || [];
+        if(!Array.isArray(arr)) arr = [];
+        arr.push({initials, country, score, date: formatDate(new Date())});
+        arr.sort((a,b)=>b.score-a.score);
+        arr = arr.slice(0,10);
+        await db.ref("scores").set(arr);
+    } catch(e){
+        console.error("Failed to submit global score", e);
+    }
+}
+
+async function checkGlobalHighScore(score){
+    const scores = await fetchGlobalScores();
+    const withPlayer = scores.concat({initials:"", country:"", score, date: formatDate(new Date())});
+    withPlayer.sort((a,b)=>b.score-a.score);
+    const rank = withPlayer.findIndex(s=>s.initials==="" && s.score===score)+1;
+    if(rank<=10){
+        let initials = prompt("Enter initials (3 letters):","") || "???";
+        initials = initials.toUpperCase().slice(0,3);
+        let country = "";
+        try{
+            const res = await fetch("https://ipapi.co/country/");
+            if(res.ok) country = await res.text();
+        }catch(e){}
+        if(!country) country = prompt("Enter country code:","") || "";
+        await submitGlobalScore(initials, country, score);
+    await fetchGlobalScores();
+    }
+}
+
 function initializeGame(shouldTryLoad = true) {
     const initialRange = Math.min(canvasWidth, canvasHeight) / 4;
 
@@ -1387,6 +1452,9 @@ function gameOver() {
     getElement('gameOverScreen').style.display = 'flex';
     getElement('finalStats').textContent = `Final Credits: ${gameState.credits} | Waves Survived: ${gameState.wave} | Score: ${gameState.score}`;
     recordHighScore(gameState.score);
+    if (getElement("enableOnlineLeaderboard").checked) {
+        checkGlobalHighScore(gameState.score);
+    }
     saveGame(); // Save final state on game over
 }
 
@@ -2964,6 +3032,13 @@ getElement('saveHighScoreButton').onclick = saveHighScoreFromModal;
 getElement('toggleInfoButton').onclick = toggleRingInfoDisplay;
 getElement('themeButton').onclick = cycleTheme; // Added Theme Button Listener
 getElement('loadButton').onclick = loadAndStartGame; // Added Load Button Listener
+getElement('enableOnlineLeaderboard').onchange = e => {
+    if (e.target.checked) {
+        fetchGlobalScores();
+    } else {
+        getElement('globalHighScores').innerHTML = "";
+    }
+};
 
 // Window Resize
 window.addEventListener('resize', () => {


### PR DESCRIPTION
## Summary
- add "Enable Online Leaderboard" section on the game over screen
- include Firebase scripts and config for hosting on GitHub Pages
- implement `fetchGlobalScores`, `submitGlobalScore`, `checkGlobalHighScore`
- hook online leaderboard toggle and game over logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c211980ec8322bcb9ac3482fca33b