### PR TITLE
Improve enemy target brackets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v2.36
 - Added "Sensors" upgrade category with enemy outlines, health bars and targeting AI.
+- Targeted enemies now keep solid red brackets briefly after locking on.
 
 ## v2.35
 - Polished line connections and made focus radius notches rectangular.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ See [CHANGELOG.md](CHANGELOG.md) for the full history.
 
 ### v2.36
 - Added Sensors upgrade category with enemy outlines, health bars and targeting AI.
+- Targeted enemies now keep solid red brackets for a short time.
 
 ### v2.35
 - Polished upgrade lines and swapped triangle notches for rectangles.

--- a/index.html
+++ b/index.html
@@ -562,6 +562,7 @@ const CONFIG = {
     MISSILE_FIRE_INTERVAL: 2000, // ms
     LASER_FIRE_INTERVAL: 500, // ms
     STUN_EFFECT_DURATION: 2000, // ms
+    TARGET_LOCK_DURATION: 300, // ms brackets stay red this long after targeting
     AUTO_SAVE_INTERVAL: 60000, // ms (1 minute)
     DRAG_THRESHOLD: 5, // pixels to initiate drag vs click
     CANVAS_CLICK_TOLERANCE: 20 // pixels tolerance for clicking ring UI
@@ -587,6 +588,7 @@ const {
   MISSILE_FIRE_INTERVAL,
   LASER_FIRE_INTERVAL,
   STUN_EFFECT_DURATION,
+  TARGET_LOCK_DURATION,
   AUTO_SAVE_INTERVAL,
   DRAG_THRESHOLD,
   CANVAS_CLICK_TOLERANCE
@@ -742,6 +744,7 @@ function resetEnemy(enemy, config) {
     enemy.type = config.type || 'Normal';
 
     enemy.isTargeted = false;
+    enemy.targetLockTime = 0;
 
     enemy.allocatedDamage = 0;
 
@@ -944,8 +947,8 @@ function drawParticles() {
     // ctx.globalAlpha = 1; // Reset alpha if applied individually
 }
 
-function drawBracket(x, y, size, color = '#ffcc00') {
-    const pulse = 1 + 0.1 * Math.sin(Date.now() / 200);
+function drawBracket(x, y, size, color = '#ffcc00', pulsing = true) {
+    const pulse = pulsing ? 1 + 0.1 * Math.sin(Date.now() / 200) : 1;
     const s = size * pulse;
     ctx.strokeStyle = color;
     ctx.lineWidth = 1;
@@ -1559,8 +1562,11 @@ function updateGame(dt) {
     // Apply game speed multiplier to delta time
     const effectiveDt = dt * gameSpeedMultiplier;
 
-    // Reset targeting flags
-    enemyPool.getActiveObjects().forEach(e => e.isTargeted = false);
+    // Countdown target lock timers
+    enemyPool.getActiveObjects().forEach(e => {
+        e.targetLockTime = Math.max(0, (e.targetLockTime || 0) - effectiveDt * 1000);
+        e.isTargeted = e.targetLockTime > 0;
+    });
 
     handleBaseMovement(effectiveDt);
     const baseMoved = updateEnemies(effectiveDt); // Returns true if base drag/return caused global move
@@ -1753,7 +1759,10 @@ function handlePlayerFiring(dt) {
 
             for (let i = 0; i < base.gunBarrelCount; i++) {
                 const t = targets[i] || nearestEnemy;
-                if (t) t.isTargeted = true;
+                if (t) {
+                    t.isTargeted = true;
+                    t.targetLockTime = TARGET_LOCK_DURATION;
+                }
                 const angle = Math.atan2(t.y - base.y, t.x - base.x);
                 const shade = Math.floor((i - (base.gunBarrelCount - 1) / 2) * 20);
                 bulletPool.get({
@@ -1780,6 +1789,7 @@ function handlePlayerFiring(dt) {
         if (targets.length > 0) {
              targets.forEach(target => {
                 target.isTargeted = true;
+                target.targetLockTime = TARGET_LOCK_DURATION;
                 const angle = Math.atan2(target.y - base.y, target.x - base.x);
                 const launchAngle = angle + (Math.random() - 0.5) * (Math.PI / 8); // Launch spread
 
@@ -1815,6 +1825,7 @@ function handlePlayerFiring(dt) {
 
         if (laserTarget) {
             laserTarget.isTargeted = true;
+            laserTarget.targetLockTime = TARGET_LOCK_DURATION;
             laserTarget.health -= base.laserDamage;
             gameState.lastLaserFireTime = currentTime;
             gameState.laserEffectEndTime = currentTime + 200; // Duration of visual effect
@@ -1903,6 +1914,7 @@ function updateProjectiles(dt, baseMoved) {
         // 2. Steering Logic
         if (targetEnemy) {
             targetEnemy.isTargeted = true;
+            targetEnemy.targetLockTime = TARGET_LOCK_DURATION;
             const dx = targetEnemy.x - missile.x;
             const dy = targetEnemy.y - missile.y;
             const targetAngle = Math.atan2(dy, dx);
@@ -2216,7 +2228,7 @@ function drawGame() {
         const showBracket = sensorDisplayMode !== 'off' || enemy.isTargeted;
         if (showBracket) {
             const color = enemy.isTargeted ? '#ff0000' : '#ffcc00';
-            drawBracket(enemy.x, enemy.y, bracketSize, color);
+            drawBracket(enemy.x, enemy.y, bracketSize, color, !enemy.isTargeted);
         }
 
         if (sensorUpgrades.enemyVisuals) {


### PR DESCRIPTION
## Summary
- add `TARGET_LOCK_DURATION` setting
- keep `enemy.isTargeted` true for a short time instead of one frame
- stop pulsing brackets during that lock

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684d47659ca4832284c58922cf359f82