### PR TITLE
Fix leaderboard saving/fallback

### DIFF
--- a/index.html
+++ b/index.html
@@ -1127,13 +1127,13 @@ const HIGH_SCORES_KEY = 'orbitalDefenseHighScores_v2.38';
 const LEADERBOARD_URL = "https://script.google.com/macros/s/AKfycbxNdo4XN4XWdpPRyRQmxC6yOsEG4MihGrlXDmI1thlaXOwD2QX00b4JHvYBDtqoK9k1/exec";
 
 // Send score to global leaderboard
-function submitScoreToLeaderboard(name, wave, time) {
+function submitScoreToLeaderboard(initials, wave, time) {
   const date = new Date().toISOString().split("T")[0];
   fetch(LEADERBOARD_URL, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
-      name: name.slice(0, 3).toUpperCase(),
+      initials: initials.slice(0, 3).toUpperCase(),
       wave,
       time,
       date
@@ -1259,7 +1259,12 @@ function updateGameOverLeaderboard() {
     title.textContent = "Global Leaderboard";
     fetchGlobalLeaderboard(rows => {
         const scores = rows.slice(0, 10).map(r => ({ initials: r[0], wave: r[1], time: r[2], date: r[3] }));
-        renderHighScores("gameOverHighScores", scores);
+        if (scores.length) {
+            renderHighScores("gameOverHighScores", scores);
+        } else {
+            title.textContent = "Local Leaderboard";
+            renderHighScores("gameOverHighScores", loadHighScores());
+        }
     }).catch(() => {
         title.textContent = "Local Leaderboard";
         renderHighScores("gameOverHighScores", loadHighScores());
@@ -1271,7 +1276,12 @@ function openHighScoreScreen() {
     title.textContent = "Global Leaderboard";
     fetchGlobalLeaderboard(rows => {
         const scores = rows.slice(0, 10).map(r => ({ initials: r[0], wave: r[1], time: r[2], date: r[3] }));
-        renderHighScores("highScoreTable", scores);
+        if (scores.length) {
+            renderHighScores("highScoreTable", scores);
+        } else {
+            title.textContent = "Local Leaderboard";
+            renderHighScores("highScoreTable", loadHighScores());
+        }
     }).catch(() => {
         title.textContent = "Local Leaderboard";
         renderHighScores("highScoreTable", loadHighScores());


### PR DESCRIPTION
## Summary
- send `initials` when submitting to the global leaderboard
- fall back to local leaderboard when global leaderboard is empty

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e64620bfc83228c3c8757569f07d2