### PR TITLE
Fix leaderboard submission encoding

### DIFF
--- a/index.html
+++ b/index.html
@@ -1129,15 +1129,16 @@ const LEADERBOARD_URL = "https://script.google.com/macros/s/AKfycbxNdo4XN4XWdpPR
 // Send score to global leaderboard
 function submitScoreToLeaderboard(name, wave, time) {
   const date = new Date().toISOString().split("T")[0];
+  const params = new URLSearchParams({
+    name: name.slice(0, 3).toUpperCase(),
+    wave,
+    time,
+    date
+  });
   fetch(LEADERBOARD_URL, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      name: name.slice(0, 3).toUpperCase(),
-      wave,
-      time,
-      date
-    })
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: params.toString()
   })
     .then(res => console.log("Score submitted"))
     .catch(err => console.error("Score submit failed", err));


### PR DESCRIPTION
## Summary
- encode posted score with URLSearchParams
- submit data as `application/x-www-form-urlencoded`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e811e9d2083228988645b86339d18