### PR TITLE
Fix leaderboard submission encoding

### DIFF
--- a/index.html
+++ b/index.html
@@ -1128,23 +1128,23 @@ const LEADERBOARD_URL = "https://script.google.com/macros/s/AKfycbxNdo4XN4XWdpPR
 
 // Send score to global leaderboard
 function submitScoreToLeaderboard(name, wave, time) {
-  const payload = {
-    name: name.slice(0, 3).toUpperCase(),
-    wave,
-    time,
-    date: new Date().toISOString().split("T")[0]
-  };
+  const params = new URLSearchParams();
+  params.set('name', name.slice(0, 3).toUpperCase());
+  params.set('wave', wave);
+  params.set('time', time);
+  params.set('date', new Date().toISOString().split('T')[0]);
+
   return fetch(LEADERBOARD_URL, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(payload)
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: params.toString()
   })
     .then(res => {
-      console.log("Score submitted");
+      console.log('Score submitted');
       return res;
     })
     .catch(err => {
-      console.error("Score submit failed", err);
+      console.error('Score submit failed', err);
       throw err;
     });
 }


### PR DESCRIPTION
## Summary
- use URLSearchParams to send `name`, `wave`, `time`, and `date`
- post to leaderboard with `application/x-www-form-urlencoded`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e8c13109483228aecef55fe69b3f8