### PR TITLE
Update leaderboard sync logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Orbital Defence Elite - Change Log
 
+## v2.38
+- Local high scores now replace lower entries on the shared leaderboard instead of adding new rows.
+- Dates returned from the global leaderboard no longer include a time component.
+
 ## v2.37.1
 - Improved touch controls so upgrades open on a single tap.
 

--- a/README.md
+++ b/README.md
@@ -31,15 +31,31 @@ control the shared leaderboard location.
 
    ```javascript
    function doGet() {
-     return ContentService.createTextOutput(
-       JSON.stringify(SpreadsheetApp.getActive().getSheetByName('Leaderboard')
-       .getDataRange().getValues()));
+     const sheet = SpreadsheetApp.getActive().getSheetByName('Leaderboard');
+     const data = sheet.getDataRange().getValues().map(r => {
+       if (r[3] instanceof Date) {
+         r[3] = Utilities.formatDate(r[3], 'GMT', 'yyyy-MM-dd');
+       }
+       return r;
+     });
+     return ContentService.createTextOutput(JSON.stringify(data));
    }
 
    function doPost(e) {
-     SpreadsheetApp.getActive().getSheetByName('Leaderboard')
-       .appendRow([e.parameter.name, e.parameter.wave, e.parameter.time,
-                   e.parameter.date]);
+     const sheet = SpreadsheetApp.getActive().getSheetByName('Leaderboard');
+     const row = [e.parameter.name, e.parameter.wave, e.parameter.time,
+                  e.parameter.date];
+     const idx = e.parameter.replaceIndex
+       ? parseInt(e.parameter.replaceIndex, 10) + 2
+       : null;
+     if (idx) {
+       sheet.getRange(idx, 1, 1, 4).setValues([row]);
+     } else {
+       sheet.appendRow(row);
+     }
+     if (sheet.getLastRow() > 11) {
+       sheet.deleteRow(sheet.getLastRow());
+     }
      return ContentService.createTextOutput('OK');
    }
    ```
@@ -56,6 +72,10 @@ player's name, wave reached, completion time in seconds and submission date.
 
 The game is under active development. Below is a brief summary of recent updates.
 See [CHANGELOG.md](CHANGELOG.md) for the full history.
+
+### v2.38
+- Local high scores replace lower entries on the global leaderboard.
+- Global leaderboard dates no longer include a time value.
 
 ### v2.37
 - Added Electronic FOV sensor upgrade with visible radius ring.

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 <!-- V2.9: Major refactor - Canvas Ring UI, Descriptive Names, Constants, Update Loop Split -->
 <!-- Added Phaser library -->
 <script src="https://cdn.jsdelivr.net/npm/phaser@3.60.0/dist/phaser.min.js"></script>
-<title>Orbital Defence Elite v2.37 - Optimised</title>
+<title>Orbital Defence Elite v2.38 - Optimised</title>
 <link rel="icon" type="image/x-icon" href="favicon.ico">
 <style>
 :root{--bg-gradient:linear-gradient(135deg,#0f2027,#203a43,#2c5364);--body-bg:#000;--text-color:#fff;--hud-color:#fff;--title-color:#fff;--final-stats-color:#cfab52;--button-bg:#2c220f;--button-text:#e6b54b;--button-border:#e6b54b;--button-hover-bg:#1c1404;--button-disabled-bg:#2f240c;--button-disabled-text:#ac4834;--upgrade-title-color:#e6b54b;--toggle-active-bg:#1c1404;--toggle-active-text:#e6b54b;--toast-bg:rgba(0,0,0,.7);--toast-text:#fff;--switch-bg:#2f240c;--switch-slider-color:#e6b54b;--switch-checked-bg:#1c1404;--switch-label-color:#e6b54b;--stats-border:rgba(230,181,75,.3);--stats-bg:rgba(0,0,0,.4);--hotkey-bg:rgba(0,0,0,.6);--hotkey-text:rgba(230,181,75,.8);--canvas-bg:rgba(0,0,0,.7);--crt-overlay-bg:linear-gradient(rgba(0,0,0,.6) 50%,transparent);--crt-overlay-blend:overlay;--crt-scanline-color:rgba(0,0,0,.1);--crt-vignette:radial-gradient(circle at center,transparent 60%,rgba(0,0,0,.6) 100%);--crt-interlace-color:rgba(0,0,0,.25);--font-family:"Press Start 2P",monospace;--button-font-size:24px;--upgrade-button-font-size:16px;--tab-font-size:14px;--ring-ui-font-size:11px}*{font-family:var(--font-family);box-sizing:border-box;padding:0}*,body{margin:0}body{overflow:hidden;background:var(--body-bg);color:var(--text-color)}#crt-overlay{position:fixed;top:0;left:0;width:100vw;height:100vh;pointer-events:none;z-index:9999;background-image:var(--crt-overlay-bg);background-size:100% 2px;background-blend-mode:var(--crt-overlay-blend)}#gameCanvas{background:var(--canvas-bg);touch-action:none}#gameCanvas,.bg{position:absolute;top:0;left:0}.bg{width:100%;height:100%;background:var(--bg-gradient);z-index:-1}#hud{position:absolute;top:0;left:10px;right:10px;display:flex;justify-content:space-between;align-items:center;font-size:var(--hud-font-size);padding:0;z-index:10;line-height:2;min-height:0;color:var(--hud-color)}#gameOverScreen h1,#startScreen h1{font-size:2rem;text-align:center;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;color:var(--title-color)}#gameOverScreen h1{font-size:5rem;margin-bottom:1rem}#hud span{flex:1;text-align:center;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}#hud #creditsDisplay{text-align:left}#hud #healthDisplay{text-align:right}#gameOverScreen,#highScoreModal,#highScoreScreen,#sensorWarning,#startScreen{position:absolute;top:0;left:0;right:0;bottom:0;display:flex;flex-direction:column;justify-content:center;align-items:center;background:rgba(0,0,0,.8);text-align:center;z-index:100}#gameOverScreen #finalStats{font-size:2rem;margin-bottom:1.5rem;color:var(--final-stats-color)}button{padding:10px 20px;font-size:var(--button-font-size);line-height:1;margin-top:22px;background:var(--button-bg);color:var(--button-text);border:2px solid var(--button-border);cursor:pointer;transition:all .3s ease}button:hover{background:var(--button-hover-bg);transform:translateY(-2px);box-shadow:0 4px 8px rgba(0,0,0,.2)}button:active{transform:translateY(1px)}button:disabled{background:var(--button-disabled-bg);color:var(--button-disabled-text);cursor:not-allowed;transform:none;box-shadow:none}#controls{position:absolute;bottom:10px;right:10px;display:flex;gap:10px;z-index:10;align-items:center}#toggleInfoButton{width:30px;height:30px;padding:0;border-radius:50%;font-size:20px;line-height:20px}#toggleInfoButton.active{background-color:var(--toggle-active-bg);color:var(--toggle-active-text)}#fullscreenButton,#playPauseButton,#slowDownButton,#speedUpButton{width:30px;height:30px;padding:0;border-radius:50%;font-size:20px;line-height:20px}#speedDisplay{display:flex;align-items:center;justify-content:center;width:40px;font-size:18px}#toast{position:absolute;bottom:20px;left:50%;transform:translateX(-50%);background:var(--toast-bg);color:var(--toast-text);padding:10px 20px;border-radius:20px;z-index:1000;opacity:0;transition:opacity .3s ease;pointer-events:none}#toast.show{opacity:1}.switch{position:relative;display:inline-block;width:50px;height:24px;margin-right:10px}.switch input{opacity:0;width:0;height:0}.slider{cursor:pointer;top:0;left:0;right:0;bottom:0;background-color:var(--switch-bg);border-radius:24px}.slider,.slider:before{position:absolute;transition:.4s}.slider:before{content:"";height:16px;width:16px;left:4px;bottom:4px;background-color:var(--switch-slider-color);border-radius:50%}input:checked+.slider{background-color:var(--switch-checked-bg)}input:checked+.slider:before{transform:translateX(26px)}.switch-label{color:var(--switch-label-color);font-size:16px}.stats{display:flex;justify-content:center;gap:20px;margin-top:10px}.stats div{border:1px solid var(--stats-border);padding:5px 10px;background:var(--stats-bg);border-radius:5px}#hotkeys{position:absolute;top:60px;right:10px;background:var(--hotkey-bg);padding:5px 10px;border-radius:5px;font-size:var(--hotkey-font-size);color:var(--hotkey-text);display:none}#hotkeys.show{display:block}#sensorToggle{display:flex;align-items:center;gap:5px;font-size:var(--hotkey-font-size);color:var(--hotkey-text);z-index:10}#sensorDisplayToggle{padding:2px 8px;cursor:pointer}#enemyHUD,#sensorDisplayToggle{font-size:var(--hotkey-font-size)}#enemyHUD{position:absolute;top:100px;right:10px;background:var(--hotkey-bg);padding:5px 10px;border-radius:5px;color:var(--hotkey-text);display:none;line-height:1.2;text-align:right;z-index:10;opacity:.9}#enemyHUD.show{display:block}#highScoreTable table{width:80%;margin:0 auto;border-collapse:collapse;font-size:2rem}#highScoreTable td,#highScoreTable th{padding:4px 8px;border-bottom:1px solid var(--button-border);text-align:left}#highScoreTable td{white-space:nowrap}#highScoreTable th{font-weight:700}#highScoreTable td:last-child{text-align:right}.blinking-cursor{font-weight:700;animation:a 1s step-end infinite}@keyframes a{50%{opacity:0}}#highScoreModal input{width:5ch;text-align:center;font-size:24px;background:transparent;color:var(--text-color);border:none;border-bottom:2px solid var(--button-border);outline:none}.crt-scanlines{position:absolute;top:0;left:0;width:100%;height:100%;background:repeating-linear-gradient(0deg,var(--crt-scanline-color),var(--crt-scanline-color) 1px,transparent 0,transparent 2px);pointer-events:none}.crt-container{transform:translateZ(0);position:relative;overflow:hidden}.crt-container:before{background:var(--crt-vignette);z-index:1}.crt-container:after,.crt-container:before{content:"";position:absolute;top:0;left:0;width:100%;height:100%;pointer-events:none}.crt-container:after{background:linear-gradient(hsla(0,6%,7%,0) 50%,var(--crt-interlace-color) 0);background-size:100% 4px;z-index:2}
@@ -26,7 +26,7 @@
     <span id="healthDisplay"></span> <!-- Renamed from #h -->
 </div>
 <div id="startScreen"> <!-- Renamed from #s -->
-    <h1>Orbital Defence Elite v2.37</h1>
+    <h1>Orbital Defence Elite v2.38</h1>
     <button id="startButton">Start Game</button> <!-- Renamed from #b -->
     <button id="loadButton" style="display:none;">Load Game</button> <!-- Added Load Button -->
     <button id="highScoreButton">High Scores</button>
@@ -1127,12 +1127,13 @@ const HIGH_SCORES_KEY = 'orbitalDefenseHighScores_v2.38';
 const LEADERBOARD_URL = "https://script.google.com/macros/s/AKfycbxNdo4XN4XWdpPRyRQmxC6yOsEG4MihGrlXDmI1thlaXOwD2QX00b4JHvYBDtqoK9k1/exec";
 
 // Send score to global leaderboard
-function submitScoreToLeaderboard(name, wave, time) {
+function submitScoreToLeaderboard(name, wave, time, replaceIndex) {
   const params = new URLSearchParams();
   params.set('name', name.slice(0, 3).toUpperCase());
   params.set('wave', wave);
   params.set('time', time);
   params.set('date', new Date().toISOString().split('T')[0]);
+  if (replaceIndex !== undefined) params.set('replaceIndex', replaceIndex);
 
   return fetch(LEADERBOARD_URL, {
     method: 'POST',
@@ -1150,22 +1151,25 @@ function submitScoreToLeaderboard(name, wave, time) {
 }
 
 // Get global leaderboard scores
-function fetchGlobalLeaderboard(callback) {
+function fetchGlobalLeaderboard() {
   return fetch(LEADERBOARD_URL)
     .then(response => response.json())
-    .then(data => {
-      const sorted = data.sort((a, b) => {
-        if (b[1] !== a[1]) return b[1] - a[1];
-        return a[2] - b[2];
-      });
-      callback(sorted);
-    });
+    .then(data => data.map(r => {
+      if (r[3]) {
+        try { r[3] = new Date(r[3]).toISOString().split('T')[0]; } catch(e) {}
+      }
+      return r;
+    }))
+    .then(rows => rows.sort((a, b) => {
+      if (b[1] !== a[1]) return b[1] - a[1];
+      return a[2] - b[2];
+    }));
 }
 
 // Combine local and global leaderboards
 function getCombinedLeaderboard(callback) {
     const local = loadHighScores().map(s => ({ ...s, source: 'local' }));
-    return fetchGlobalLeaderboard(rows => {
+    return fetchGlobalLeaderboard().then(rows => {
         const global = rows.map(r => ({ initials: r[0], wave: r[1], time: r[2], date: r[3], source: 'global' }));
         const combined = local.concat(global);
         const bestMap = new Map();
@@ -1210,15 +1214,38 @@ function formatDate(date) {
 // Sync unsent local scores to the global leaderboard
 function syncLocalScoresToGlobal() {
     const scores = loadHighScores();
-    let changed = false;
-    const tasks = scores.map(s => {
-        if (!s.synced) {
-            return submitScoreToLeaderboard(s.initials, s.wave, s.time)
-                .then(() => { s.synced = true; changed = true; })
-                .catch(err => console.error('Sync failed', err));
-        }
-    }).filter(Boolean);
-    return Promise.all(tasks).then(() => { if (changed) saveHighScores(scores); });
+    const unsynced = scores.filter(s => !s.synced);
+    if (!unsynced.length) return Promise.resolve();
+
+    return fetchGlobalLeaderboard().then(rows => {
+        let globals = rows.map((r, i) => ({ initials: r[0], wave: parseInt(r[1], 10), time: parseInt(r[2], 10), index: i }));
+        globals.sort((a,b) => (b.wave - a.wave) || (a.time - b.time));
+        unsynced.sort((a,b) => (b.wave - a.wave) || (a.time - b.time));
+
+        let changed = false;
+        const tasks = [];
+
+        unsynced.forEach(local => {
+            const lowest = globals[globals.length - 1];
+            if (globals.length < 10 || local.wave > lowest.wave || (local.wave === lowest.wave && local.time < lowest.time)) {
+                const replaceIndex = globals.length < 10 ? globals.length : lowest.index;
+                tasks.push(
+                    submitScoreToLeaderboard(local.initials, local.wave, local.time, replaceIndex)
+                        .then(() => { local.synced = true; changed = true; })
+                        .catch(err => console.error('Sync failed', err))
+                );
+                if (globals.length < 10) {
+                    globals.push({ wave: local.wave, time: local.time, index: replaceIndex });
+                } else {
+                    globals[globals.findIndex(g => g.index === lowest.index)] = { wave: local.wave, time: local.time, index: replaceIndex };
+                }
+                globals.sort((a,b) => (b.wave - a.wave) || (a.time - b.time));
+                globals = globals.slice(0,10);
+            }
+        });
+
+        return Promise.all(tasks).then(() => { if (changed) saveHighScores(scores); });
+    });
 }
 
 let pendingHighScore = null;


### PR DESCRIPTION
## Summary
- prevent timestamp leakage in global scores
- replace low global scores instead of appending
- document new Apps Script snippet for replace API
- update version to v2.38

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e9379145c8322875d949d4c7e2594