### PR TITLE
Fix CORS error on score submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,13 @@ Scores are automatically synced to a shared Google Sheet whenever you finish a
 run and have an internet connection. The game submits your name, wave, time and
 date to the URL defined by `LEADERBOARD_URL` in
 [`index.html`](index.html), which points to a hosted Apps Script that backs the
-public leaderboard. No additional setup is necessary&mdash;just play and your
-best scores will appear alongside everyone else's.
+public leaderboard. In some environments the request may fail because the
+leaderboard does not provide CORS headers. The code now sends the score using
+`no-cors` mode so the request still completes even if the response cannot be
+read.
 
-If you prefer to maintain your own leaderboard, you can still deploy a copy of
-the script and update `LEADERBOARD_URL` to your URL.
+If you prefer to maintain your own leaderboard or require full CORS support,
+deploy a copy of the script yourself and update `LEADERBOARD_URL` accordingly.
 
 ## Change Log
 

--- a/index.html
+++ b/index.html
@@ -1132,16 +1132,14 @@ function submitScoreToLeaderboard(initials, wave, time) {
     const date = new Date().toISOString().slice(0, 10).replace(/-/g, '');
     const data = { initials, wave, time, date };
 
+    // Using no-cors mode avoids preflight requests which can fail on some
+    // leaderboard deployments. The response becomes opaque, so we simply
+    // fire-and-forget and log any fetch errors.
     return fetch(LEADERBOARD_URL, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        mode: 'no-cors',
         body: JSON.stringify(data)
     })
-        .then(response => response.text())
-        .then(result => {
-            console.log('Score submitted:', result);
-            return result;
-        })
         .catch(error => {
             console.error('Error submitting score:', error);
             throw error;


### PR DESCRIPTION
## Summary
- handle preflight issues by using `no-cors` mode when sending scores
- explain leaderboard CORS limitations in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684eccf6c5288322bd30a33129815c7a