### PR TITLE
Implement CORS headers for leaderboard

### DIFF
--- a/apps-script.js
+++ b/apps-script.js
@@ -10,7 +10,8 @@ function getSheet() {
 function doGet(e) {
   const values = getSheet().getDataRange().getValues();
   return ContentService.createTextOutput(JSON.stringify(values))
-    .setMimeType(ContentService.MimeType.JSON);
+    .setMimeType(ContentService.MimeType.JSON)
+    .setHeader('Access-Control-Allow-Origin', '*');
 }
 
 function doPost(e) {
@@ -32,5 +33,12 @@ function doPost(e) {
   if (!updated) {
     sheet.appendRow([payload.initials, payload.wave, payload.time, payload.date]);
   }
-  return ContentService.createTextOutput('ok');
+  return ContentService.createTextOutput('ok')
+    .setHeader('Access-Control-Allow-Origin', '*');
+}
+
+function doOptions(e) {
+  return ContentService.createTextOutput('')
+    .setMimeType(ContentService.MimeType.TEXT)
+    .setHeader('Access-Control-Allow-Origin', '*');
 }

--- a/index.html
+++ b/index.html
@@ -1125,7 +1125,7 @@ function loadGame() {
 
 const HIGH_SCORES_KEY = 'orbitalDefenseHighScores_v2.38';
 // Hosted Google Apps Script backing the shared leaderboard
-const LEADERBOARD_URL = "https://script.google.com/macros/s/AKfycbxNdo4XN4XWdpPRyRQmxC6yOsEG4MihGrlXDmI1thlaXOwD2QX00b4JHvYBDtqoK9k1/exec";
+const LEADERBOARD_URL = "https://script.google.com/macros/s/YOUR_NEW_DEPLOYMENT_ID/exec";
 
 // Send score to global leaderboard
 function submitScoreToLeaderboard(initials, wave, time) {

--- a/leaderboard_tester.html
+++ b/leaderboard_tester.html
@@ -29,7 +29,7 @@
     <tbody></tbody>
   </table>
 <script>
-const LEADERBOARD_URL = "https://script.google.com/macros/s/AKfycbxNdo4XN4XWdpPRyRQmxC6yOsEG4MihGrlXDmI1thlaXOwD2QX00b4JHvYBDtqoK9k1/exec";
+const LEADERBOARD_URL = "https://script.google.com/macros/s/YOUR_NEW_DEPLOYMENT_ID/exec";
 
 
 function cleanDate(value) {


### PR DESCRIPTION
## Summary
- allow cross-origin access in `apps-script.js`
- show stub `doOptions` handler
- update `LEADERBOARD_URL` placeholder to a redeployed endpoint in `index.html` and tester

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684fc4540670832282743cc041bab794