### PR TITLE
Update Firebase SDK references

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,8 +11,9 @@
 <!-- Added Phaser library -->
 <script src="https://cdn.jsdelivr.net/npm/phaser@3.60.0/dist/phaser.min.js"></script>
 <script type="module">
-import { initializeApp } from "https://www.gstatic.com/firebasejs/10.12.0/firebase-app.js";
-import { getDatabase, ref, push, get } from "https://www.gstatic.com/firebasejs/10.12.0/firebase-database.js";
+import { initializeApp } from "https://www.gstatic.com/firebasejs/11.9.1/firebase-app.js";
+import { getDatabase, ref, push, get } from "https://www.gstatic.com/firebasejs/11.9.1/firebase-database.js";
+import { getAnalytics } from "https://www.gstatic.com/firebasejs/11.9.1/firebase-analytics.js";
 
 const firebaseConfig = {
   apiKey: "YOUR_API_KEY",

--- a/leaderboard_tester.html
+++ b/leaderboard_tester.html
@@ -31,8 +31,9 @@
 </body>
 </html>
 <script type="module">
-import { initializeApp } from "https://www.gstatic.com/firebasejs/10.12.0/firebase-app.js";
-import { getDatabase, ref, push, get } from "https://www.gstatic.com/firebasejs/10.12.0/firebase-database.js";
+import { initializeApp } from "https://www.gstatic.com/firebasejs/11.9.1/firebase-app.js";
+import { getDatabase, ref, push, get } from "https://www.gstatic.com/firebasejs/11.9.1/firebase-database.js";
+import { getAnalytics } from "https://www.gstatic.com/firebasejs/11.9.1/firebase-analytics.js";
 
 const firebaseConfig = {
   apiKey: "YOUR_API_KEY",


### PR DESCRIPTION
## Summary
- upgrade Firebase module URLs to version 11.9.1 in `index.html` and `leaderboard_tester.html`
- add `getAnalytics` import

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853bc5fde5c83228d1a13dd2cb4753a