### PR TITLE
Update leaderboard error handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,6 +38,7 @@ window.submitScore = function(initials, wave, timeLeft) {
 };
 
 window.loadTopScores = function(callback) {
+  const message = document.getElementById('leaderboardMessage');
   get(ref(db, 'scores')).then(snapshot => {
     const data = snapshot.val() || {};
     const scores = Object.values(data);
@@ -45,7 +46,11 @@ window.loadTopScores = function(callback) {
       if (b.wave !== a.wave) return b.wave - a.wave;
       return a.timeLeft - b.timeLeft;
     });
+    if (message) message.textContent = '';
     callback(scores.slice(0,10));
+  }).catch(err => {
+    console.error(err);
+    if (message) message.textContent = 'Unable to load leaderboard.';
   });
 };
 </script>
@@ -76,6 +81,7 @@ window.loadTopScores = function(callback) {
     <div id="leaderboardSection" style="display:none;flex-direction:column;align-items:center;gap:20px;">
         <h2>Leaderboard</h2>
         <table id="leaderboardTable"><thead><tr><th>Init</th><th>Wave</th><th>Time</th><th>Date</th></tr></thead><tbody></tbody></table>
+        <p id="leaderboardMessage"></p>
         <button id="leaderboardBack">Back</button>
     </div>
     <button id="restartButton">Play Again</button> <!-- Renamed from #r -->

--- a/leaderboard_tester.html
+++ b/leaderboard_tester.html
@@ -54,15 +54,23 @@ function submitScore(initials, wave, timeLeft) {
 }
 
 function loadTopScores() {
-  return get(ref(db, 'scores')).then(snap => {
-    const data = snap.val() || {};
-    const scores = Object.values(data);
-    scores.sort((a,b) => {
-      if (b.wave !== a.wave) return b.wave - a.wave;
-      return a.timeLeft - b.timeLeft;
+  const message = document.getElementById('leaderboardMessage');
+  return get(ref(db, 'scores'))
+    .then(snap => {
+      const data = snap.val() || {};
+      const scores = Object.values(data);
+      scores.sort((a,b) => {
+        if (b.wave !== a.wave) return b.wave - a.wave;
+        return a.timeLeft - b.timeLeft;
+      });
+      if (message) message.textContent = '';
+      return scores.slice(0,10);
+    })
+    .catch(err => {
+      console.error(err);
+      if (message) message.textContent = 'Unable to load leaderboard.';
+      throw err;
     });
-    return scores.slice(0,10);
-  });
 }
 
 function renderLeaderboard(rows) {


### PR DESCRIPTION
## Summary
- add leaderboardMessage element in the game over section
- clear or set leaderboardMessage in loadTopScores depending on success or failure
- propagate the same error handling to leaderboard tester

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853bf4889c08322b57db5ebab337cd9