### PR TITLE
Fix leaderboard initialization order

### DIFF
--- a/index.html
+++ b/index.html
@@ -472,7 +472,7 @@ const THEMES = [
     }
 ];
 </script>
-<script>
+<script defer>
 (function(){ // IIFE to encapsulate code
 "use strict";
 let currentThemeIndex = 0;


### PR DESCRIPTION
## Summary
- defer the main game script so Firebase helpers load first

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853c3c740a08322aee8bc36af02328c