### PR TITLE
Fix leaderboard init in main index

### DIFF
--- a/index.html
+++ b/index.html
@@ -3357,13 +3357,9 @@ function loadAndStartGame() {
 // --- Global Access (for HTML onclick) ---
 window.purchaseUpgrade = purchaseUpgrade; // Make purchase function global for button clicks
 window.toggleUpgradeCategory = toggleUpgradeCategory; // Expose category toggling
-// Sample leaderboard usage
-submitScore("AAA", 5, 45).then(() => {
-    loadTopScores(scores => console.log("Top scores", scores));
-});
-
-
-
+// Sample leaderboard usage removed to avoid errors if Firebase scripts
+// have not finished loading when this file executes. Use submitScore and
+// loadTopScores within the game flow once Firebase is ready.
 })(); // End IIFE
 </script>
 <div id="crt-overlay"></div>


### PR DESCRIPTION
## Summary
- remove sample leaderboard call that ran before firebase setup
- leave instructions for calling `submitScore` after firebase loads

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853c541ce548322a6367745d0026a80