### PR TITLE
Add initials entry for leaderboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository contains a small browser game written entirely in a single HTML 
 ## Playing
 
 Open `index.html` in any modern browser. The game will load immediately with no additional assets required. Use the on-screen instructions or the hotkeys listed on the start screen to play.
-High scores are saved in your browser via `localStorage`, so they persist between sessions.
+High scores are saved in your browser via `localStorage`, so they persist between sessions. After a game ends you can enter up to three initials on the Game Over screen to submit your score to the online leaderboard.
 
 ## About
 
@@ -27,7 +27,8 @@ Follow these steps to set up your own instance:
 4. Replace the placeholders in [`firebaseConfig.js`](firebaseConfig.js) with your config object.
 5. Deploy the game to GitHub Pages or open it locally to test.
 6. Scores will be written under the `scores` path and the top ten will appear in the leaderboard section.
-7. To prevent unauthorized writes, consider using HTTP referrer restrictions or enabling Firebase App Check.
+7. Players submit scores by entering their initials on the Game Over screen.
+8. To prevent unauthorized writes, consider using HTTP referrer restrictions or enabling Firebase App Check.
 
 ## Change Log
 

--- a/index.html
+++ b/index.html
@@ -74,6 +74,7 @@ window.loadTopScores = function(callback) {
 <div id="gameOverScreen" style="display:none"> <!-- Renamed from #o -->
     <h1>Game Over</h1>
     <div id="finalStats"></div> <!-- Renamed from #f -->
+    <input id="initialsInput" maxlength="3">
     <button id="restartButton">Play Again</button> <!-- Renamed from #r -->
 </div>
 <div id="controls">
@@ -1418,6 +1419,7 @@ function startGame() {
     }
     getElement('startScreen').style.display = 'none';
     getElement('gameOverScreen').style.display = 'none';
+    getElement('initialsInput').value = '';
     pauseGame(); // Ensure no game loop is running
     gameSpeedMultiplier = 1;
     speedIndex = SPEED_STEPS.indexOf(1);
@@ -1441,7 +1443,10 @@ function gameOver() {
     getElement('finalStats').textContent = `Wave ${gameState.wave}/${survivalTime}s - ${formatDate(new Date())}`;
     saveGame(); // Save final state on game over
     if (navigator.onLine) {
-        submitScore('AAA', gameState.wave, survivalTime).then(() => {
+        const initialsField = getElement('initialsInput');
+        let initials = (initialsField.value || '').trim().toUpperCase();
+        if (!initials) initials = 'AAA';
+        submitScore(initials, gameState.wave, survivalTime).then(() => {
             loadTopScores(renderLeaderboard);
         });
     }


### PR DESCRIPTION
## Summary
- add initials input to the Game Over screen
- read initials when submitting the score and clear field when starting
- document entering initials in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853cc2b41e0832288b8237e0edc4d46