### PR TITLE
Fix outdated localStorage docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Orbital Defence Elite - Change Log
 
 ## v2.38
-- Local high scores now replace lower entries on the shared leaderboard instead of adding new rows.
+- Switched to a Firebase-only leaderboard; local storage has been removed.
 - Dates returned from the global leaderboard no longer include a time component.
 
 ## v2.37.1
@@ -31,7 +31,7 @@
 ## v2.32
 - Added persistent Top 10 High Scores feature
 - Scores include 3-character initials, score, and date
-- Scores are saved in browser `localStorage`
+- Scores were initially saved in browser `localStorage` (now replaced by Firebase)
 - Retro arcade-style visual leaderboard
 - Automatically initializes when no high scores exist
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository contains a small browser game written entirely in a single HTML 
 ## Playing
 
 Open `index.html` in any modern browser. The game will load immediately with no additional assets required. Use the on-screen instructions or the hotkeys listed on the start screen to play.
-High scores are saved in your browser via `localStorage`, so they persist between sessions.
+High scores are stored online using Firebase Realtime Database, so they persist across devices.
 
 ## About
 
@@ -35,7 +35,7 @@ The game is under active development. Below is a brief summary of recent updates
 See [CHANGELOG.md](CHANGELOG.md) for the full history.
 
 ### v2.38
-- Local high scores replace lower entries on the global leaderboard.
+- Switched to Firebase-only high scores and removed local storage.
 - Global leaderboard dates no longer include a time value.
 
 ### v2.37


### PR DESCRIPTION
## Summary
- clarify that high scores use Firebase
- adjust v2.38 summary notes
- note historic localStorage usage in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853cc5693ac83228529a34c9342f67c