### PR TITLE
Remove unused analytics import

### DIFF
--- a/leaderboard_tester.html
+++ b/leaderboard_tester.html
@@ -36,7 +36,6 @@
 <script type="module">
 import { initializeApp } from "https://www.gstatic.com/firebasejs/11.9.1/firebase-app.js";
 import { getDatabase, ref, push, get } from "https://www.gstatic.com/firebasejs/11.9.1/firebase-database.js";
-import { getAnalytics } from "https://www.gstatic.com/firebasejs/11.9.1/firebase-analytics.js";
 
 import { firebaseConfig } from "./firebaseConfig.js";
 const app = initializeApp(firebaseConfig);


### PR DESCRIPTION
## Summary
- remove the unused `getAnalytics` import from `leaderboard_tester.html`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853cc5f78a08322baa521cd1db2028a