### PR TITLE
Add leaderboard sorting test

### DIFF
--- a/__tests__/leaderboard.test.js
+++ b/__tests__/leaderboard.test.js
@@ -1,0 +1,23 @@
+import { sortScores } from '../leaderboard.js';
+
+test('sortScores returns top 10 scores by wave and time', () => {
+  const scores = [
+    { initials: 'A', wave: 2, timeLeft: 10 },
+    { initials: 'B', wave: 3, timeLeft: 20 },
+    { initials: 'C', wave: 3, timeLeft: 5 },
+    { initials: 'D', wave: 1, timeLeft: 50 },
+    { initials: 'E', wave: 4, timeLeft: 40 },
+    { initials: 'F', wave: 4, timeLeft: 35 },
+    { initials: 'G', wave: 5, timeLeft: 25 },
+    { initials: 'H', wave: 2, timeLeft: 5 },
+    { initials: 'I', wave: 5, timeLeft: 30 },
+    { initials: 'J', wave: 1, timeLeft: 10 },
+    { initials: 'K', wave: 3, timeLeft: 15 },
+    { initials: 'L', wave: 5, timeLeft: 20 }
+  ];
+
+  const sorted = sortScores([...scores]);
+  const top10 = sorted.slice(0, 10).map(s => s.initials);
+  const expected = ['L','G','I','F','E','C','K','B','H','A'];
+  expect(top10).toEqual(expected);
+});

--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
 import { initializeApp } from "https://www.gstatic.com/firebasejs/11.9.1/firebase-app.js";
 import { getDatabase, ref, push, get } from "https://www.gstatic.com/firebasejs/11.9.1/firebase-database.js";
 import { firebaseConfig } from "./firebaseConfig.js";
+import { sortScores } from "./leaderboard.js";
 const app = initializeApp(firebaseConfig);
 const db = getDatabase(app);
 
@@ -32,10 +33,7 @@ window.loadTopScores = function(callback) {
   get(ref(db, 'scores')).then(snapshot => {
     const data = snapshot.val() || {};
     const scores = Object.values(data);
-    scores.sort((a,b) => {
-      if (b.wave !== a.wave) return b.wave - a.wave;
-      return a.timeLeft - b.timeLeft;
-    });
+    sortScores(scores);
     if (message) message.textContent = '';
     callback(scores.slice(0,10));
   }).catch(err => {

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+export default {
+  testEnvironment: 'node'
+};

--- a/leaderboard.js
+++ b/leaderboard.js
@@ -1,0 +1,8 @@
+export function sortScores(scores) {
+  return scores.sort((a, b) => {
+    if (b.wave !== a.wave) {
+      return b.wave - a.wave;
+    }
+    return a.timeLeft - b.timeLeft;
+  });
+}

--- a/leaderboard_tester.html
+++ b/leaderboard_tester.html
@@ -39,6 +39,7 @@ import { getDatabase, ref, push, get } from "https://www.gstatic.com/firebasejs/
 import { getAnalytics } from "https://www.gstatic.com/firebasejs/11.9.1/firebase-analytics.js";
 
 import { firebaseConfig } from "./firebaseConfig.js";
+import { sortScores } from "./leaderboard.js";
 const app = initializeApp(firebaseConfig);
 const db = getDatabase(app);
 
@@ -48,17 +49,14 @@ function submitScore(initials, wave, timeLeft) {
 
 function loadTopScores() {
   const message = document.getElementById('leaderboardMessage');
-  return get(ref(db, 'scores'))
-    .then(snap => {
-      const data = snap.val() || {};
-      const scores = Object.values(data);
-      scores.sort((a,b) => {
-        if (b.wave !== a.wave) return b.wave - a.wave;
-        return a.timeLeft - b.timeLeft;
-      });
-      if (message) message.textContent = '';
-      return scores.slice(0,10);
-    })
+    return get(ref(db, 'scores'))
+      .then(snap => {
+        const data = snap.val() || {};
+        const scores = Object.values(data);
+        sortScores(scores);
+        if (message) message.textContent = '';
+        return scores.slice(0,10);
+      })
     .catch(err => {
       console.error(err);
       if (message) message.textContent = 'Unable to load leaderboard.';

--- a/package.json
+++ b/package.json
@@ -3,7 +3,11 @@
   "version": "1.0.0",
   "description": "Self-contained browser game",
   "private": true,
+  "type": "module",
   "scripts": {
-    "test": "echo \"No tests specified\" && exit 0"
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
+  },
+  "devDependencies": {
+    "jest": "^30.0.1"
   }
 }


### PR DESCRIPTION
## Summary
- add `jest` dev dependency and configure ESM test environment
- move leaderboard sorting into `leaderboard.js`
- adjust HTML files to import the new module
- add Jest test verifying top‑10 sorting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853cc63be408322945cf4dc50a538a2