### PR TITLE
Add Firebase leaderboard and UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,12 @@
 :root{--bg-gradient:linear-gradient(135deg,#0f2027,#203a43,#2c5364);--body-bg:#000;--text-color:#fff;--hud-color:#fff;--title-color:#fff;--final-stats-color:#cfab52;--button-bg:#2c220f;--button-text:#e6b54b;--button-border:#e6b54b;--button-hover-bg:#1c1404;--button-disabled-bg:#2f240c;--button-disabled-text:#ac4834;--upgrade-title-color:#e6b54b;--toggle-active-bg:#1c1404;--toggle-active-text:#e6b54b;--toast-bg:rgba(0,0,0,.7);--toast-text:#fff;--switch-bg:#2f240c;--switch-slider-color:#e6b54b;--switch-checked-bg:#1c1404;--switch-label-color:#e6b54b;--stats-border:rgba(230,181,75,.3);--stats-bg:rgba(0,0,0,.4);--hotkey-bg:rgba(0,0,0,.6);--hotkey-text:rgba(230,181,75,.8);--canvas-bg:rgba(0,0,0,.7);--crt-overlay-bg:linear-gradient(rgba(0,0,0,.6) 50%,transparent);--crt-overlay-blend:overlay;--crt-scanline-color:rgba(0,0,0,.1);--crt-vignette:radial-gradient(circle at center,transparent 60%,rgba(0,0,0,.6) 100%);--crt-interlace-color:rgba(0,0,0,.25);--font-family:"Press Start 2P",monospace;--button-font-size:24px;--upgrade-button-font-size:16px;--tab-font-size:14px;--ring-ui-font-size:11px}*{font-family:var(--font-family);box-sizing:border-box;padding:0}*,body{margin:0}body{overflow:hidden;background:var(--body-bg);color:var(--text-color)}#crt-overlay{position:fixed;top:0;left:0;width:100vw;height:100vh;pointer-events:none;z-index:9999;background-image:var(--crt-overlay-bg);background-size:100% 2px;background-blend-mode:var(--crt-overlay-blend)}#gameCanvas{background:var(--canvas-bg);touch-action:none}#gameCanvas,.bg{position:absolute;top:0;left:0}.bg{width:100%;height:100%;background:var(--bg-gradient);z-index:-1}#hud{position:absolute;top:0;left:10px;right:10px;display:flex;justify-content:space-between;align-items:center;font-size:var(--hud-font-size);padding:0;z-index:10;line-height:2;min-height:0;color:var(--hud-color)}#gameOverScreen h1,#startScreen h1{font-size:2rem;text-align:center;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;color:var(--title-color)}#gameOverScreen h1{font-size:5rem;margin-bottom:1rem}#hud span{flex:1;text-align:center;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}#hud #creditsDisplay{text-align:left}#hud #healthDisplay{text-align:right}#gameOverScreen,#highScoreModal,#highScoreScreen,#sensorWarning,#startScreen{position:absolute;top:0;left:0;right:0;bottom:0;display:flex;flex-direction:column;justify-content:center;align-items:center;background:rgba(0,0,0,.8);text-align:center;z-index:100}#gameOverScreen #finalStats{font-size:2rem;margin-bottom:1.5rem;color:var(--final-stats-color)}button{padding:10px 20px;font-size:var(--button-font-size);line-height:1;margin-top:22px;background:var(--button-bg);color:var(--button-text);border:2px solid var(--button-border);cursor:pointer;transition:all .3s ease}button:hover{background:var(--button-hover-bg);transform:translateY(-2px);box-shadow:0 4px 8px rgba(0,0,0,.2)}button:active{transform:translateY(1px)}button:disabled{background:var(--button-disabled-bg);color:var(--button-disabled-text);cursor:not-allowed;transform:none;box-shadow:none}#controls{position:absolute;bottom:10px;right:10px;display:flex;gap:10px;z-index:10;align-items:center}#toggleInfoButton{width:30px;height:30px;padding:0;border-radius:50%;font-size:20px;line-height:20px}#toggleInfoButton.active{background-color:var(--toggle-active-bg);color:var(--toggle-active-text)}#fullscreenButton,#playPauseButton,#slowDownButton,#speedUpButton{width:30px;height:30px;padding:0;border-radius:50%;font-size:20px;line-height:20px}#speedDisplay{display:flex;align-items:center;justify-content:center;width:40px;font-size:18px}#toast{position:absolute;bottom:20px;left:50%;transform:translateX(-50%);background:var(--toast-bg);color:var(--toast-text);padding:10px 20px;border-radius:20px;z-index:1000;opacity:0;transition:opacity .3s ease;pointer-events:none}#toast.show{opacity:1}.switch{position:relative;display:inline-block;width:50px;height:24px;margin-right:10px}.switch input{opacity:0;width:0;height:0}.slider{cursor:pointer;top:0;left:0;right:0;bottom:0;background-color:var(--switch-bg);border-radius:24px}.slider,.slider:before{position:absolute;transition:.4s}.slider:before{content:"";height:16px;width:16px;left:4px;bottom:4px;background-color:var(--switch-slider-color);border-radius:50%}input:checked+.slider{background-color:var(--switch-checked-bg)}input:checked+.slider:before{transform:translateX(26px)}.switch-label{color:var(--switch-label-color);font-size:16px}.stats{display:flex;justify-content:center;gap:20px;margin-top:10px}.stats div{border:1px solid var(--stats-border);padding:5px 10px;background:var(--stats-bg);border-radius:5px}#hotkeys{position:absolute;top:60px;right:10px;background:var(--hotkey-bg);padding:5px 10px;border-radius:5px;font-size:var(--hotkey-font-size);color:var(--hotkey-text);display:none}#hotkeys.show{display:block}#sensorToggle{display:flex;align-items:center;gap:5px;font-size:var(--hotkey-font-size);color:var(--hotkey-text);z-index:10}#sensorDisplayToggle{padding:2px 8px;cursor:pointer}#enemyHUD,#sensorDisplayToggle{font-size:var(--hotkey-font-size)}#enemyHUD{position:absolute;top:100px;right:10px;background:var(--hotkey-bg);padding:5px 10px;border-radius:5px;color:var(--hotkey-text);display:none;line-height:1.2;text-align:right;z-index:10;opacity:.9}#enemyHUD.show{display:block}#highScoreTable table{width:80%;margin:0 auto;border-collapse:collapse;font-size:2rem}#highScoreTable td,#highScoreTable th{padding:4px 8px;border-bottom:1px solid var(--button-border);text-align:left}#highScoreTable td{white-space:nowrap}#highScoreTable th{font-weight:700}#highScoreTable td:last-child{text-align:right}.blinking-cursor{font-weight:700;animation:a 1s step-end infinite}@keyframes a{50%{opacity:0}}#highScoreModal input{width:5ch;text-align:center;font-size:24px;background:transparent;color:var(--text-color);border:none;border-bottom:2px solid var(--button-border);outline:none}.crt-scanlines{position:absolute;top:0;left:0;width:100%;height:100%;background:repeating-linear-gradient(0deg,var(--crt-scanline-color),var(--crt-scanline-color) 1px,transparent 0,transparent 2px);pointer-events:none}.crt-container{transform:translateZ(0);position:relative;overflow:hidden}.crt-container:before{background:var(--crt-vignette);z-index:1}.crt-container:after,.crt-container:before{content:"";position:absolute;top:0;left:0;width:100%;height:100%;pointer-events:none}.crt-container:after{background:linear-gradient(hsla(0,6%,7%,0) 50%,var(--crt-interlace-color) 0);background-size:100% 4px;z-index:2}
 </style>
 <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&family=VT323&family=Share+Tech+Mono&family=Rajdhani&family=Orbitron&display=swap" rel="stylesheet">
+<style>
+  #highScoreList, #gameOverScoreList { list-style: none; padding: 0; margin: 1rem 0; }
+  #highScoreList li, #gameOverScoreList li { margin: 0.2rem 0; }
+  #initialsInput { font-size: 2rem; text-align: center; width: 4ch; background: transparent; border: none; border-bottom: 2px solid var(--button-text); color: var(--button-text); caret-color: var(--button-text); }
+  #cheekyMessage { margin: 1rem 0; color: var(--button-text); }
+</style>
 </head>
 <body>
 <div class="bg"></div>
@@ -30,10 +36,18 @@
     <h1>Orbital Defence Elite v2.38</h1>
     <button id="startButton">Start Game</button> <!-- Renamed from #b -->
     <button id="loadButton" style="display:none;">Load Game</button> <!-- Added Load Button -->
+    <button id="leaderboardButton">Leaderboard</button>
+</div>
+<div id="highScoreScreen" style="display:none">
+    <h1>Top Pilots</h1>
+    <ol id="highScoreList"></ol>
+    <button id="startFromHighScore">Start Game</button>
 </div>
 <div id="gameOverScreen" style="display:none"> <!-- Renamed from #o -->
     <h1>Game Over</h1>
     <div id="finalStats"></div> <!-- Renamed from #f -->
+    <ol id="gameOverScoreList"></ol>
+    <div id="cheekyMessage"></div>
     <input id="initialsInput" maxlength="3">
     <button id="restartButton">Play Again</button> <!-- Renamed from #r -->
 </div>
@@ -917,6 +931,23 @@ function showToast(message, duration = 2000) {
     }, duration);
 }
 
+function renderScoreList(id, scores) {
+    const list = getElement(id);
+    list.innerHTML = '';
+    scores.forEach(s => {
+        const li = document.createElement('li');
+        li.textContent = `${s.initials} - ${s.score}`;
+        list.appendChild(li);
+    });
+}
+
+function showHighScores() {
+    getElement('startScreen').style.display = 'none';
+    getElement('gameOverScreen').style.display = 'none';
+    getElement('highScoreScreen').style.display = 'flex';
+    getTopScores(scores => renderScoreList('highScoreList', scores));
+}
+
 function showSensorWarning() {
     getElement('sensorWarning').style.display = 'flex';
 }
@@ -929,6 +960,34 @@ function dismissSensorWarning() {
     gameState.waveDuration = WAVE_BASE_DURATION + (gameState.wave - 1) * WAVE_DURATION_INCREMENT;
     resumeGame();
     showToast('Wave timer started! Enemies approaching just outside your range.', 3000);
+}
+
+function manualSubmitTestScore() {
+    getTopScores(scores => {
+        const tenth = scores[9] ? scores[9].score : 0;
+        const score = tenth + 1;
+        const letters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+        const initials = Array.from({length:3}, () => letters[Math.floor(Math.random()*26)]).join('');
+        const wave = parseInt(prompt('Wave number', gameState.wave)) || gameState.wave;
+        const time = parseInt(prompt('Time (seconds)', 0)) || 0;
+        const date = prompt('Date (YYYYMMDD)', formatDate(new Date())) || formatDate(new Date());
+        submitScore(initials, wave, time, date, score).then(() => {
+            showToast('Test score submitted');
+            getTopScores(s => renderScoreList('highScoreList', s));
+        });
+    });
+}
+
+function submitInitials() {
+    let initials = getElement('initialsInput').value.toUpperCase();
+    if (initials.length === 2) initials += '_';
+    if (initials.length < 2) return;
+    const survivalTime = Math.floor((Date.now() - gameStartTime) / 1000);
+    submitScore(initials, gameState.wave, survivalTime, formatDate(new Date()), gameState.score).then(() => {
+        showToast('Score submitted!');
+        getElement('initialsInput').style.display = 'none';
+        getTopScores(scores => renderScoreList('gameOverScoreList', scores));
+    });
 }
 
 function updateHUD() {
@@ -1340,6 +1399,14 @@ function initializeGame(shouldTryLoad = true) {
                     maxLevel: Infinity,
                     f: () => {},
                     g: () => ''
+                },
+                {
+                    name: 'Manual Submit Test Score',
+                    cost: 0,
+                    level: 0,
+                    maxLevel: Infinity,
+                    f: manualSubmitTestScore,
+                    g: () => ''
                 }
             ]
         }
@@ -1356,6 +1423,7 @@ function initializeGame(shouldTryLoad = true) {
 function startGame() {
     initializeGame(true); // Initialize with saved game check
     getElement('startScreen').style.display = 'none';
+    getElement('highScoreScreen').style.display = 'none';
     getElement('gameOverScreen').style.display = 'none';
     getElement('initialsInput').value = '';
     pauseGame(); // Ensure no game loop is running
@@ -1379,6 +1447,31 @@ function gameOver() {
     getElement('gameOverScreen').style.display = 'flex';
     const survivalTime = Math.floor((Date.now() - gameStartTime) / 1000);
     getElement('finalStats').textContent = `Wave ${gameState.wave}/${survivalTime}s - ${formatDate(new Date())}`;
+    const currentScore = gameState.score;
+    getTopScores(scores => {
+        renderScoreList('gameOverScoreList', scores);
+        const qualifies = scores.length < 10 || currentScore > scores[scores.length - 1].score;
+        if (qualifies) {
+            getElement('initialsInput').style.display = 'block';
+            getElement('cheekyMessage').textContent = '';
+            getElement('initialsInput').focus();
+        } else {
+            const phrases = [
+                'So close, yet orbital debris…',
+                'Your score called. It wants another chance.',
+                'Your gran could’ve done better… but we believe in you.',
+                'Launch again, recruit.',
+                'Good news: you’re in the Top 1000!',
+                'Now serving humble pie.',
+                'Failure builds character. Try again?',
+                'Almost made it. Like, just almost.',
+                'Mission: failed. Style: impeccable.',
+                'It’s not about the score. It’s about the… no wait, it is about the score.'
+            ];
+            getElement('initialsInput').style.display = 'none';
+            getElement('cheekyMessage').textContent = phrases[Math.floor(Math.random()*phrases.length)];
+        }
+    });
     saveGame(); // Save final state on game over
 }
 
@@ -3166,6 +3259,15 @@ getElement('macrossButton').onclick = fireMacrossMissiles;
 getElement('toggleInfoButton').onclick = toggleRingInfoDisplay;
 getElement('themeButton').onclick = cycleTheme; // Added Theme Button Listener
 getElement('loadButton').onclick = loadAndStartGame; // Added Load Button Listener
+getElement('leaderboardButton').onclick = showHighScores;
+getElement('startFromHighScore').onclick = startGame;
+getElement('initialsInput').addEventListener('keydown', e => {
+    if (e.key === 'Enter') submitInitials();
+});
+getElement('initialsInput').addEventListener('input', e => {
+    e.target.value = e.target.value.toUpperCase();
+    if (e.target.value.length >= 3) submitInitials();
+});
 getElement('sensorDisplayToggle').onclick = cycleSensorDisplayMode;
 getElement('fullscreenButton').onclick = toggleFullScreen;
 
@@ -3282,6 +3384,32 @@ function loadAndStartGame() {
 window.purchaseUpgrade = purchaseUpgrade; // Make purchase function global for button clicks
 window.toggleUpgradeCategory = toggleUpgradeCategory; // Expose category toggling
 })(); // End IIFE
+</script>
+<script type="module">
+import { initializeApp } from 'https://www.gstatic.com/firebasejs/11.9.1/firebase-app.js';
+import { getDatabase, ref, push, query, orderByChild, limitToLast, get } from 'https://www.gstatic.com/firebasejs/11.9.1/firebase-database.js';
+const firebaseConfig = {
+  apiKey: "AIzaSyA5CSbcR_DS601s5Ok_f-UOT_dobysD9eU",
+  authDomain: "lb-1file.firebaseapp.com",
+  databaseURL: "https://lb-1file-default-rtdb.firebaseio.com",
+  projectId: "lb-1file",
+  storageBucket: "lb-1file.appspot.com",
+  messagingSenderId: "828776232983",
+  appId: "1:828776232983:web:a1e7b73bf46b1e5124c452",
+  measurementId: "G-BTTQRHEFSJ"
+};
+const app = initializeApp(firebaseConfig);
+const db = getDatabase(app);
+window.submitScore = (initials, wave, time, date, score) => push(ref(db, 'scores'), { initials, wave, time, date, score, secret: 'MY_SUPER_SECRET_321' });
+window.getTopScores = cb => {
+  const q = query(ref(db, 'scores'), orderByChild('score'), limitToLast(10));
+  get(q).then(snap => {
+    const arr = [];
+    snap.forEach(c => arr.push(c.val()));
+    arr.sort((a,b) => b.score - a.score);
+    cb(arr);
+  });
+};
 </script>
 <div id="crt-overlay"></div>
 </body>


### PR DESCRIPTION
## Summary
- integrate Firebase realtime DB via module scripts
- add Leaderboard screen with Start Game button
- allow entering initials to submit global scores
- show and submit test scores from debug menu

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_68565e1845088322aad461cccb77548b