### PR TITLE
Fix leaderboard render

### DIFF
--- a/index.html
+++ b/index.html
@@ -941,8 +941,9 @@ function renderScoreList(id, scores) {
         return;
     }
     scores.forEach(s => {
+        const timeLeft = (s.time ?? 0);
         const li = document.createElement('li');
-        li.textContent = `${s.initials} - Wave ${s.wave} (${s.time}s left)`;
+        li.textContent = `${s.initials} - Wave ${s.wave} (${timeLeft}s left)`;
         list.appendChild(li);
     });
 }


### PR DESCRIPTION
## Summary
- handle scores without time in `renderScoreList`

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_68566dc6f0048322b7f3af22248bddc6