### PR TITLE
Improve leaderboard debug logging

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,8 +41,12 @@
   window.getTopScores = async function() {
     const q = query(ref(db, "scores"), orderByChild("ranking"), limitToLast(10));
     const snap = await get(q);
+    console.log("getTopScores snapshot size:", snap.size);
     const list = [];
-    snap.forEach(child => list.push(child.val()));
+    snap.forEach(child => {
+      console.log("  key:", child.key, "->", child.val().ranking);
+      list.push(child.val());
+    });
     list.sort((a, b) => b.ranking - a.ranking);
     return list;
   };
@@ -50,9 +54,14 @@
   window.listenToLeaderboard = callback => {
     const q = query(ref(db, "scores"), orderByChild("ranking"), limitToLast(10));
     leaderboardUnsub = onValue(q, snap => {
+      console.log("listen snapshot children:", snap.size);
       const list = [];
-      snap.forEach(child => list.push(child.val()));
+      snap.forEach(child => {
+        console.log("  key:", child.key, "->", child.val().ranking);
+        list.push(child.val());
+      });
       list.sort((a, b) => b.ranking - a.ranking);
+      console.log("sorted list length:", list.length, list);
       callback(list);
     });
   };
@@ -80,7 +89,10 @@
   };
 
   // 5) Hook up “Leaderboard” button
-  document.getElementById("show-leaderboard").addEventListener("click", () => {
+  document.getElementById("show-leaderboard").addEventListener("click", async () => {
+    document.getElementById("startScreen").style.display = "none";
+    const scores = await getTopScores();
+    renderLeaderboard(scores);
     listenToLeaderboard(renderLeaderboard);
     document.getElementById("leaderboard-screen").style.display = "block";
   });


### PR DESCRIPTION
## Summary
- add debug console logs to inspect leaderboard snapshot
- prime leaderboard with `getTopScores` before subscribing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685697d1a1c8832283592a8a46ed5cfb