### PR TITLE
Fix leaderboard item alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,6 +106,7 @@
 <style>
   #highScoreList, #gameOverScoreList, #leaderboard { list-style: none; padding: 0; margin: 1rem 0; }
   #highScoreList li, #gameOverScoreList li, .leaderboard-row { margin: 0.2rem 0; }
+  #gameOverScoreList li, .leaderboard-row { text-align: left; }
   .rank { display: inline-block; width: 2ch; }
   #initialsInput { font-size: 2rem; text-align: center; width: 4ch; background: transparent; border: none; border-bottom: 2px solid var(--button-text); color: var(--button-text); caret-color: var(--button-text); }
   #cheekyMessage { margin: 1rem 0; color: var(--button-text); }


### PR DESCRIPTION
## Summary
- ensure `#gameOverScoreList li` and `.leaderboard-row` are left aligned

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68578e569f6c8322bc62d08fb9c15a4f