### PR TITLE
Handle Escape key on leaderboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -3135,6 +3135,13 @@ window.addEventListener('keydown', e => {
 
     keysPressed[e.key.toLowerCase()] = true; // Use lower case for consistency
 
+    // Close leaderboard screen with Escape
+    if (e.key === 'Escape' && getElement('leaderboard-screen').style.display !== 'none') {
+        getElement('leaderboard-screen').style.display = 'none';
+        unlistenLeaderboard();
+        getElement('startScreen').style.display = 'flex';
+    }
+
     // Handle single-press actions only if game is running
     if (isGameRunning) {
         switch (e.key.toLowerCase()) {


### PR DESCRIPTION
## Summary
- close the leaderboard when Escape is pressed
- stop listening for leaderboard updates and show the start screen

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685790ddbb548322bf6dbb8d69d0ebc5