### PR TITLE
Add leaderboard loading spinner

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,6 +81,7 @@
       div.innerHTML = `<span class="rank">${i + 1}.</span> ${row}`;
       container.appendChild(div);
     }
+    document.getElementById("leaderboardLoading").style.display = "none";
   };
 
   // 5) Hook up “Leaderboard” button
@@ -105,6 +106,17 @@
   .rank { display: inline-block; width: 2ch; }
   #initialsInput { font-size: 2rem; text-align: center; width: 4ch; background: transparent; border: none; border-bottom: 2px solid var(--button-text); color: var(--button-text); caret-color: var(--button-text); }
   #cheekyMessage { margin: 1rem 0; color: var(--button-text); }
+  #leaderboardLoading {
+    display: none;
+    width: 2rem;
+    height: 2rem;
+    margin: 1rem auto;
+    border: 0.4rem solid var(--button-text);
+    border-top-color: transparent;
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+  }
+  @keyframes spin { to { transform: rotate(360deg); } }
 </style>
 </head>
 <body>
@@ -123,8 +135,9 @@
 </div>
 <div id="leaderboard-screen" style="display:none">
     <h1>Global Leaderboard</h1>
-    <div id="leaderboard"></div>
-    <button id="startFromHighScore">Start Game</button>
+  <div id="leaderboard"></div>
+  <div id="leaderboardLoading"></div>
+  <button id="startFromHighScore">Start Game</button>
 </div>
 <div id="gameOverScreen" style="display:none"> <!-- Renamed from #o -->
     <h1>Game Over</h1>
@@ -1037,6 +1050,7 @@ function showHighScores() {
     getElement('startScreen').style.display = 'none';
     getElement('gameOverScreen').style.display = 'none';
     getElement('leaderboard-screen').style.display = 'flex';
+    getElement('leaderboardLoading').style.display = 'block';
     listenToLeaderboard(renderLeaderboard);
 }
 


### PR DESCRIPTION
## Summary
- add `#leaderboardLoading` spinner element
- style spinner with simple CSS animation
- display spinner while scores load and hide after render

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_6857910022a0832295149f810546d03c