### PR TITLE
Improve leaderboard row defaults

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,7 +89,7 @@
     for (let i = 0; i < 10; i++) {
       const row = scores[i]
         ? `${scores[i].initials} - Wave ${scores[i].wave} (${scores[i].time}s left) - ${scores[i].date}`
-        : "&nbsp;";
+        : "---";
       const div = document.createElement("div");
       div.className = "leaderboard-row";
       div.innerHTML = `<span class="rank">${i + 1}.</span> ${row}`;
@@ -1069,13 +1069,12 @@ function renderScoreList(id, scores) {
         const li = document.createElement('li');
         li.textContent = 'No scores yet';
         list.appendChild(li);
-        return;
     }
     for (let i = 0; i < 10; i++) {
         const li = document.createElement('li');
         const entry = scores[i]
             ? `${scores[i].initials} - Wave ${scores[i].wave} (${scores[i].time ?? 0}s left) - ${scores[i].date}`
-            : "&nbsp;";
+            : "---";
         li.innerHTML = `<span class="rank">${i + 1}.</span> ${entry}`;
         list.appendChild(li);
     }


### PR DESCRIPTION
## Summary
- keep rendering all rows even without scores
- show placeholders with `---` for score gaps

## Testing
- `git diff --cached`

------
https://chatgpt.com/codex/tasks/task_e_68579bb9fb148322835efe3b9cfae815