### PR TITLE
Fix enemy HUD positioning

### DIFF
--- a/index.html
+++ b/index.html
@@ -3223,9 +3223,13 @@ function updateEnemyHUD(info) {
 
     const hudBar = getElement('hud');
     const hotkeys = getElement('hotkeys');
+    const panel = getElement('enemyStatsPanel');
     let top = hudBar.offsetHeight + 10;
     if (hotkeys.classList.contains('show')) {
         top += hotkeys.offsetHeight + 10;
+    }
+    if (panel) {
+        top += panel.offsetHeight + 10;
     }
     hud.style.top = top + 'px';
 


### PR DESCRIPTION
## Summary
- reposition HUD info below enemy stats panel to avoid overlap

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68579da75324832287cf37c7798dbb54