### PR TITLE
Fix enemy popup overlay on page load

### DIFF
--- a/index.html
+++ b/index.html
@@ -219,7 +219,7 @@
     <p>Upgrade "Sensors" Electronic FOV to see enemies outside this ring. The wave timer has started – enemies approach from beyond your sight.</p>
     <button id="sensorWarningButton">Continue</button>
 </div>
-<div id="enemyIdentificationPopup"><div class="card"><h2>Enemy Identified</h2><div id="enemyIntelContent"></div><button id="enemyIntelContinue">Continue</button></div></div>
+<div id="enemyIdentificationPopup" style="display:none"><div class="card"><h2>Enemy Identified</h2><div id="enemyIntelContent"></div><button id="enemyIntelContinue">Continue</button></div></div>
 <div id="toast"></div>
 <!-- Removed shipSprite image as it wasn't used -->
 


### PR DESCRIPTION
## Summary
- hide enemy identification popup by default so it doesn't show on first load

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6857a63e2ea883229710ebf14546f3f1