### PR TITLE
Highlight leaderboard row

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,19 +86,20 @@
   window.renderLeaderboard = (scores, highlightIndex = -1) => {
     const container = document.getElementById("leaderboard");
     container.textContent = "";
-    for (let i = 0; i < 10; i++) {
-      const row = scores[i]
-        ? `${scores[i].initials} - Wave ${scores[i].wave} (${scores[i].time}s left) - ${scores[i].date}`
-        : "---";
-      const div = document.createElement("div");
-      div.className = "leaderboard-row";
-      const rankSpan = document.createElement("span");
-      rankSpan.className = "rank";
-      rankSpan.textContent = `${i + 1}.`;
-      div.appendChild(rankSpan);
-      div.appendChild(document.createTextNode(" " + (row === "&nbsp;" ? "\u00A0" : row)));
-      container.appendChild(div);
-    }
+      for (let i = 0; i < 10; i++) {
+        const row = scores[i]
+          ? `${scores[i].initials} - Wave ${scores[i].wave} (${scores[i].time}s left) - ${scores[i].date}`
+          : "---";
+        const div = document.createElement("div");
+        div.className = "leaderboard-row";
+        const rankSpan = document.createElement("span");
+        rankSpan.className = "rank";
+        rankSpan.textContent = `${i + 1}.`;
+        div.appendChild(rankSpan);
+        div.appendChild(document.createTextNode(" " + (row === "&nbsp;" ? "\u00A0" : row)));
+        if (i === highlightIndex) div.classList.add("highlight");
+        container.appendChild(div);
+      }
     document.getElementById("leaderboardLoading").style.display = "none";
   };
 
@@ -126,7 +127,13 @@
   #highScoreList li, #gameOverScoreList li, .leaderboard-row { margin: 0.2rem 0; }
   #gameOverScoreList li, .leaderboard-row { text-align: left; }
   .rank { display: inline-block; width: 2ch; }
-  .highlight { background: rgba(255,255,255,0.2); }
+  .highlight {
+    background: yellow;
+    color: black;
+    border: 2px solid black;
+    font-size: 1.2em;
+    padding: 0.2rem;
+  }
   #initialsInput { font-size: 2rem; text-align: center; width: 4ch; background: transparent; border: none; border-bottom: 2px solid var(--button-text); color: var(--button-text); caret-color: var(--button-text); }
   #cheekyMessage { margin: 1rem 0; color: var(--button-text); }
   #leaderboardLoading {
@@ -1111,6 +1118,7 @@ function renderScoreList(id, scores, highlightIndex = -1) {
         rankSpan.textContent = `${i + 1}.`;
         li.appendChild(rankSpan);
         li.appendChild(document.createTextNode(' ' + (entry === "&nbsp;" ? "\u00A0" : entry)));
+        if (i === highlightIndex) li.classList.add('highlight');
         list.appendChild(li);
     }
 }


### PR DESCRIPTION
## Summary
- bring back highlight for player's leaderboard row after submitting initials
- use yellow highlight box to emphasize new leaderboard placement

## Testing
- `grep -n highlight index.html | head`


------
https://chatgpt.com/codex/tasks/task_e_6857b6d6d520832296192b19bab123dc