### PR TITLE
Add hidden debug upgrade toggle

### DIFF
--- a/design/debug-upgrades.md
+++ b/design/debug-upgrades.md
@@ -1,0 +1,14 @@
+# Debug Upgrade Toggle Design
+
+The debug category grants instant credits for testing. It should remain hidden
+from normal players. A new boolean `debugUpgradesVisible` controls whether the
+category appears in the upgrade list.
+
+* **Default**: `debugUpgradesVisible` is `false` so the category does not render
+  and is ignored when checking upgrade availability.
+* **Toggle**: Pressing the `Q` key flips this flag and redraws the UI. When
+  visible, the debug upgrade behaves like any other upgrade.
+* **Hotkeys**: The toggle is intentionally undocumented and not listed in the
+  hotkeys overlay.
+
+This design keeps the code self-contained without adding new UI elements.

--- a/index.html
+++ b/index.html
@@ -730,6 +730,7 @@ let animationFrameId = null;
 let savedGame = null; // Stores loaded game state
 let autoSaveTimer = null;
 let DEBUG_MODE = false; // Set to true to enable verbose logging
+let debugUpgradesVisible = false; // Hidden debug upgrade category toggle
 let lastBaseX = 0;
 let lastBaseY = 0;
 window.pendingScore = null; // Store score awaiting initials
@@ -2239,10 +2240,11 @@ function checkWaveCompletion(dt) {
 }
 
 function updateUpgradeAvailabilityFlags() {
-    // Check if any upgrade is affordable
-    gameState.upgradesAvailable = upgradeTree.some(category =>
-        category.upgrades.some(u => gameState.credits >= u.cost && u.level < u.maxLevel)
-    );
+    // Check if any upgrade is affordable, ignoring hidden debug category
+    gameState.upgradesAvailable = upgradeTree.some((category, idx) => {
+        if (idx === UPGRADE_CATEGORY_DEBUG && !debugUpgradesVisible) return false;
+        return category.upgrades.some(u => gameState.credits >= u.cost && u.level < u.maxLevel);
+    });
     // Base color change removed, could be added back if desired
 }
 
@@ -2308,6 +2310,7 @@ function drawGame() {
     const categorySpacing = 10;
 
     upgradeTree.forEach((category, i) => {
+        if (i === UPGRADE_CATEGORY_DEBUG && !debugUpgradesVisible) return;
         const color = getCategoryColor(i);
         const hasAvailable = category.upgrades.some(u => gameState.credits >= u.cost && u.level < u.maxLevel);
         const h = drawCollapsibleUpgradeElement(menuX, currentY, category.category, category, i, category.expanded, color, hasAvailable);
@@ -3451,6 +3454,10 @@ window.addEventListener('keydown', e => {
                 }
                 break;
             case 'i': toggleEnemyStatsPanel(); break;
+            case 'q':
+                debugUpgradesVisible = !debugUpgradesVisible;
+                drawGame();
+                break; // Hidden toggle for debug upgrades
             case 'o': toggleRingInfoDisplay(); break; // Toggle info anytime
         }
     }

--- a/tasks/debug-upgrades.md
+++ b/tasks/debug-upgrades.md
@@ -1,0 +1,8 @@
+# Implement hidden debug upgrade toggle
+
+1. Define `debugUpgradesVisible = false` alongside other global flags.
+2. Skip the debug category in `updateUpgradeAvailabilityFlags` and when drawing
+   upgrade lists unless the flag is true.
+3. Bind the `Q` key in the main `keydown` handler to toggle the flag and redraw
+   the game.
+4. The hotkeys overlay does not mention this shortcut.


### PR DESCRIPTION
## Summary
- hide Debug upgrade category by default
- toggle Debug upgrades with the `Q` key
- document feature in a design note and task list

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6857b7b7b2588322ad238a82d8053896