### PR TITLE
Enhance enemy stats panel UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -164,6 +164,7 @@
   #enemyStatsPanel { position: absolute; right: 10px; background: var(--hotkey-bg); padding: 5px 10px; border-radius: 5px; font-size: var(--hotkey-font-size); color: var(--hotkey-text); z-index: 10; }
   #enemyStatsPanel.collapsed #enemyStatsContent { display: none; }
   #enemyStatsHeader { cursor: pointer; }
+  #enemyStatsHeader .arrow { margin-left: 4px; }
 </style>
 </head>
 <body>
@@ -222,7 +223,7 @@
     <div>I: Toggle Enemy Stats</div>
     <div>O: Toggle Ring Info</div>
 </div>
-<div id="enemyStatsPanel" class="collapsed"><div id="enemyStatsHeader">Enemy Stats</div><div id="enemyStatsContent"></div></div>
+<div id="enemyStatsPanel"><div id="enemyStatsHeader">Enemy Stats <span id="enemyStatsToggle" class="arrow">▾</span></div><div id="enemyStatsContent"></div></div>
 <div id="enemyHUD"></div>
 <div id="sensorWarning" style="display:none">
     <p>The ring around your base shows your cannon's visual firing range. The cannon cannot target enemies beyond this radius. Click on the "Cannon" to upgrade the cannon's abilities.</p>
@@ -3367,7 +3368,7 @@ function updateEnemyStatsPanel(){
     const list=getElement("enemyStatsContent");
     let html="";
     enemyIntel.order.forEach(t=>{const d=enemyIntel.known[t];html+=`<div>${t}: Spd ${d.speed} HP ${d.health}</div>`;});
-    list.innerHTML=html||"<div>No data</div>";
+    list.innerHTML=html||"<div>Purchase Enemy Identification under Sensors upgrades</div>";
     const hudBar=getElement("hud");
     const hotkeys=getElement("hotkeys");
     let top=hudBar.offsetHeight+10;
@@ -3377,7 +3378,9 @@ function updateEnemyStatsPanel(){
 
 function toggleEnemyStatsPanel(){
     const p=getElement("enemyStatsPanel");
+    const arrow=getElement("enemyStatsToggle");
     p.classList.toggle("collapsed");
+    arrow.textContent=p.classList.contains("collapsed")?'▸':'▾';
 }
 
 function beep(){


### PR DESCRIPTION
## Summary
- enemy stats panel starts expanded and shows a toggle arrow
- CSS tweak for arrow spacing
- display upgrade hint when no intel exists
- change toggle function to update arrow icon

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6857b76cc26c83228efc8f495a1d423a