### PR TITLE
Remove Phaser overlay system

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Open `index.html` in any modern browser. The game will load immediately with no 
 
 ## About
 
-`index.html` now embeds the original `styles.css` and `themes.js` directly inside `<style>` and `<script>` tags. There are no external dependencies besides the Phaser library pulled from a CDN.
+`index.html` now embeds the original `styles.css` and `themes.js` directly inside `<style>` and `<script>` tags. There are no external dependencies beyond the Firebase scripts loaded from a CDN.
 
 The previous `css/` and `js/` folders have been removed as part of the single-file challenge.
 

--- a/index.html
+++ b/index.html
@@ -8,8 +8,6 @@
 <!-- V2.17.1: Removed theme cycling logic and hid theme button -->
 <!-- V2.17: Removed themes 2-6, updated version number -->
 <!-- V2.9: Major refactor - Canvas Ring UI, Descriptive Names, Constants, Update Loop Split -->
-<!-- Added Phaser library -->
-<script src="https://cdn.jsdelivr.net/npm/phaser@3.60.0/dist/phaser.min.js"></script>
 <script type="module">
   import { initializeApp } from "https://www.gstatic.com/firebasejs/11.9.1/firebase-app.js";
   import { getDatabase, ref, push, query, orderByChild, limitToLast, get, onValue } from "https://www.gstatic.com/firebasejs/11.9.1/firebase-database.js";
@@ -166,14 +164,12 @@
   #enemyStatsHeader { cursor: pointer; }
   #enemyStatsHeader .arrow { margin-left: 4px; }
   #overlayContainer,
-  #cssOverlay,
-  #phaserCanvas {
-    position: absolute;
-    inset: 0;
-    pointer-events: none;
-  }
+  #cssOverlay {
+      position: absolute;
+      inset: 0;
+      pointer-events: none;
+    }
   #cssOverlay { background: rgba(0,0,0,0.6); display:none; }
-  #phaserCanvas { display:none; }
   #overlayButton { margin-left:4px; }
 </style>
 </head>
@@ -774,38 +770,17 @@ let hotkeysWidth = null;
 
 
 // --- Overlay System ---
-const OVERLAY_METHODS = ['None','Canvas','Phaser','CSS','Fog'];
+const OVERLAY_METHODS = ['None','Canvas','CSS','Fog'];
 let overlayMode = 0;
 let fogCanvas = null, fogCtx = null;
-let phaserGame = null, phaserOverlay = null, phaserMask = null;
-let cssOverlay = null, phaserCanvas = null, overlayButton = null;
+let cssOverlay = null, overlayButton = null;
 
 function cycleOverlay() {
     overlayMode = (overlayMode + 1) % OVERLAY_METHODS.length;
     if (overlayButton) overlayButton.textContent = 'Overlay: ' + OVERLAY_METHODS[overlayMode];
-    if (overlayMode !== 2 && phaserGame) { phaserGame.destroy(true); phaserGame = null; }
-    if (cssOverlay) cssOverlay.style.display = overlayMode === 3 ? 'block' : 'none';
-    if (phaserCanvas) phaserCanvas.style.display = overlayMode === 2 ? 'block' : 'none';
+    if (cssOverlay) cssOverlay.style.display = overlayMode === 2 ? 'block' : 'none';
 }
 
-function setupPhaserOverlay() {
-    if (phaserGame) return;
-    phaserGame = new Phaser.Game({
-        type: Phaser.CANVAS,
-        width: canvasWidth,
-        height: canvasHeight,
-        transparent: true,
-        canvas: phaserCanvas,
-        scene: {
-            create: function() {
-                phaserOverlay = this.add.graphics();
-                phaserMask = this.add.graphics();
-                const mask = phaserMask.createGeometryMask();
-                phaserOverlay.setMask(mask);
-            }
-        }
-    });
-}
 
 function applyOverlay(radius) {
     switch (overlayMode) {
@@ -820,22 +795,11 @@ function applyOverlay(radius) {
             ctx.restore();
             break;
         case 2:
-            setupPhaserOverlay();
-            phaserOverlay.clear();
-            phaserOverlay.fillStyle(0x000000, 0.6);
-            phaserOverlay.fillRect(0,0,canvasWidth,canvasHeight);
-            phaserMask.clear();
-            phaserMask.fillStyle(0xffffff);
-            phaserMask.beginPath();
-            phaserMask.arc(base.x, base.y, radius);
-            phaserMask.fillPath();
-            break;
-        case 3:
             if (cssOverlay) {
                 cssOverlay.style.clipPath = `circle(${radius}px at ${base.x}px ${base.y}px)`;
             }
             break;
-        case 4:
+        case 3:
             if (!fogCanvas) {
                 fogCanvas = document.createElement('canvas');
                 fogCanvas.width = canvasWidth;
@@ -3411,10 +3375,6 @@ function handleFullscreenChange() {
     canvasHeight = window.innerHeight;
     canvas.width = canvasWidth;
     canvas.height = canvasHeight;
-    if (phaserCanvas) {
-        phaserCanvas.width = canvasWidth;
-        phaserCanvas.height = canvasHeight;
-    }
     if (fogCanvas) {
         fogCanvas.width = canvasWidth;
         fogCanvas.height = canvasHeight;
@@ -3875,13 +3835,11 @@ function loadAndStartGame() {
 
   overlayButton = getElement('overlayButton');
   cssOverlay = getElement('cssOverlay');
-  phaserCanvas = getElement('phaserCanvas');
   if (overlayButton) {
     overlayButton.addEventListener('click', cycleOverlay);
     overlayButton.textContent = 'Overlay: ' + OVERLAY_METHODS[overlayMode];
   }
   if (cssOverlay) cssOverlay.style.display = 'none';
-  if (phaserCanvas) phaserCanvas.style.display = 'none';
 
 
 
@@ -3902,7 +3860,6 @@ window.toggleUpgradeCategory = toggleUpgradeCategory; // Expose category togglin
 })(); // End IIFE
 </script>
 <div id="overlayContainer"></div>
-<canvas id="phaserCanvas"></canvas>
 <div id="cssOverlay"></div>
 <div id="deathOverlay" class="overlay-desaturate" style="display:none"></div>
 <div id="crt-overlay"></div>


### PR DESCRIPTION
## Summary
- drop Phaser script include
- remove Phaser overlay mode and variables
- adjust overlay cycling logic and CSS
- update README to no longer list Phaser as a dependency

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6857c72efe848322b96f62275be9d95a