### PR TITLE
Fix overlay radius

### DIFF
--- a/index.html
+++ b/index.html
@@ -2668,7 +2668,13 @@ function drawGame() {
     // --- Draw Particles ---
     drawParticles();
 
-    const visibleRadius = Math.max(base.cannonRange, base.sensorRange);
+    const visibleRadius = Math.max(
+        base.cannonRange,
+        base.missileTargetingRadius,
+        base.laserRange,
+        base.sensorRange,
+        base.stunRadius
+    );
     applyOverlay(visibleRadius);
 }
 


### PR DESCRIPTION
## Summary
- include missile, laser and stun radii when calculating the overlay area

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6857cb133d708322a68b4cee272eabfd