### PR TITLE
Ensure waves only advance after enemies spawned

### DIFF
--- a/index.html
+++ b/index.html
@@ -2406,8 +2406,9 @@ function checkWaveCompletion(dt) {
     const enemies = enemyPool.getActiveObjects();
     // Remove finished waves from display
     activeWaves = activeWaves.filter(w => waveBossAlive[w] || enemies.some(e => e.wave === w));
-    // If no enemies remain, start the next wave automatically
-    if (enemies.length === 0) {
+    // If all spawned enemies have been cleared, start the next wave
+    // but only after at least one enemy was actually spawned in this wave
+    if (enemies.length === 0 && gameState.enemiesSpawnedThisWave > 0) {
         startNextWave();
     }
 }


### PR DESCRIPTION
## Summary
- fix `checkWaveCompletion` logic so new waves start only after enemies are spawned and cleared

## Testing
- `python3 -m http.server 8000` and `curl -I http://localhost:8000/index.html`

------
https://chatgpt.com/codex/tasks/task_e_6857d309d87c83228af5770f6a16085f