### PR TITLE
Set fog overlay as default

### DIFF
--- a/index.html
+++ b/index.html
@@ -163,15 +163,7 @@
   #enemyStatsPanel.collapsed #enemyStatsContent { display: none; }
   #enemyStatsHeader { cursor: pointer; }
   #enemyStatsHeader .arrow { margin-left: 4px; }
-  #overlayContainer,
 
-  #cssOverlay {
-      position: absolute;
-      inset: 0;
-      pointer-events: none; z-index:5;
-    }
-  #cssOverlay { background: rgba(0,0,0,0.6); display:none; }
-  #overlayButton { margin-left:4px; }
 </style>
 </head>
 <body>
@@ -218,7 +210,6 @@
     </div>
     <button id="fullscreenButton">&#x26F6;</button>
     <button id="muteButton">&#128266;</button>
-    <button id="overlayButton">Overlay: None</button>
     <button id="sendWaveButton">Send Next Wave</button>
 </div>
 <div id="hotkeys" class="show">
@@ -779,66 +770,24 @@ let hotkeysWidth = null;
 
 
 // --- Overlay System ---
-const OVERLAY_METHODS = ['None','Canvas','CSS','Fog'];
-let overlayMode = 0;
 let fogCanvas = null, fogCtx = null;
-let cssOverlay = null, overlayButton = null;
-const UPGRADE_MASK_WIDTH = 600; // width of the left-side upgrade panel
-
-function cycleOverlay() {
-    overlayMode = (overlayMode + 1) % OVERLAY_METHODS.length;
-    if (overlayButton) overlayButton.textContent = 'Overlay: ' + OVERLAY_METHODS[overlayMode];
-    if (cssOverlay) cssOverlay.style.display = overlayMode === 2 ? 'block' : 'none';
-}
-
 
 function applyOverlay(radius) {
-    switch (overlayMode) {
-        case 1:
-            ctx.save();
-            ctx.fillStyle = 'rgba(0,0,0,0.6)';
-            ctx.fillRect(0,0,canvasWidth,canvasHeight);
-            ctx.globalCompositeOperation = 'destination-out';
-            ctx.beginPath();
-            ctx.arc(base.x, base.y, radius, 0, Math.PI*2);
-            ctx.fill();
-            ctx.restore();
-            break;
-        case 2:
-            if (cssOverlay) {
-                const radial = `radial-gradient(circle at ${base.x}px ${base.y}px, transparent 0, transparent ${radius}px, black ${radius}px)`;
-                const rect = 'linear-gradient(black, black)';
-                const mask = `${radial}, ${rect}`;
-                cssOverlay.style.maskImage = mask;
-                cssOverlay.style.webkitMaskImage = mask;
-                cssOverlay.style.maskSize = `100% 100%, ${UPGRADE_MASK_WIDTH}px 100%`;
-                cssOverlay.style.webkitMaskSize = `100% 100%, ${UPGRADE_MASK_WIDTH}px 100%`;
-                cssOverlay.style.maskPosition = `0 0, 0 0`;
-                cssOverlay.style.webkitMaskPosition = `0 0, 0 0`;
-                cssOverlay.style.maskRepeat = 'no-repeat, no-repeat';
-                cssOverlay.style.webkitMaskRepeat = 'no-repeat, no-repeat';
-                cssOverlay.style.maskComposite = 'subtract';
-                cssOverlay.style.webkitMaskComposite = 'xor';
-            }
-            break;
-        case 3:
-            if (!fogCanvas) {
-                fogCanvas = document.createElement('canvas');
-                fogCanvas.width = canvasWidth;
-                fogCanvas.height = canvasHeight;
-                fogCtx = fogCanvas.getContext('2d');
-            }
-            fogCtx.clearRect(0,0,canvasWidth,canvasHeight);
-            fogCtx.fillStyle = 'rgba(0,0,0,0.8)';
-            fogCtx.fillRect(0,0,canvasWidth,canvasHeight);
-            fogCtx.globalCompositeOperation = 'destination-out';
-            fogCtx.beginPath();
-            fogCtx.arc(base.x, base.y, radius, 0, Math.PI*2);
-            fogCtx.fill();
-            fogCtx.globalCompositeOperation = 'source-over';
-            ctx.drawImage(fogCanvas,0,0);
-            break;
+    if (!fogCanvas) {
+        fogCanvas = document.createElement('canvas');
+        fogCanvas.width = canvasWidth;
+        fogCanvas.height = canvasHeight;
+        fogCtx = fogCanvas.getContext('2d');
     }
+    fogCtx.clearRect(0,0,canvasWidth,canvasHeight);
+    fogCtx.fillStyle = 'rgba(0,0,0,0.8)';
+    fogCtx.fillRect(0,0,canvasWidth,canvasHeight);
+    fogCtx.globalCompositeOperation = 'destination-out';
+    fogCtx.beginPath();
+    fogCtx.arc(base.x, base.y, radius, 0, Math.PI*2);
+    fogCtx.fill();
+    fogCtx.globalCompositeOperation = 'source-over';
+    ctx.drawImage(fogCanvas,0,0);
 }
 
 // --- Object Pooling ---
@@ -4088,13 +4037,7 @@ function loadAndStartGame() {
     muteBtn.textContent = isMuted ? '\uD83D\uDD07' : '\uD83D\uDD0A';
   }
 
-  overlayButton = getElement('overlayButton');
-  cssOverlay = getElement('cssOverlay');
-  if (overlayButton) {
-    overlayButton.addEventListener('click', cycleOverlay);
-    overlayButton.textContent = 'Overlay: ' + OVERLAY_METHODS[overlayMode];
-  }
-  if (cssOverlay) cssOverlay.style.display = 'none';
+
 
 
 
@@ -4114,8 +4057,6 @@ window.purchaseUpgrade = purchaseUpgrade; // Make purchase function global for b
 window.toggleUpgradeCategory = toggleUpgradeCategory; // Expose category toggling
 })(); // End IIFE
 </script>
-<div id="overlayContainer"></div>
-<div id="cssOverlay"></div>
 <div id="deathOverlay" class="overlay-desaturate" style="display:none"></div>
 <div id="crt-overlay"></div>
 </body>


### PR DESCRIPTION
## Summary
- remove overlay chooser UI and unused overlay methods
- simplify overlay code to always use fog effect

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6857e382a4548322a33c590cf58c72a3