### PR TITLE
Add wave debug logs

### DIFF
--- a/index.html
+++ b/index.html
@@ -2094,6 +2094,7 @@ function spawnNewEnemies(dt) {
         }
 
         if (!state.isBossWave && state.elapsedTime >= state.duration) {
+            console.log(`[wave ${waveStr}] boss spawned`);
             spawnEnemy(true, Number(waveStr));
             state.isBossWave = true;
             showToast('Boss Wave!', 3000);
@@ -3635,6 +3636,7 @@ function fireMacrossMissiles() {
 
 function sendNextWave() {
     // Simply initiate the next wave without spawning the current boss early
+    console.log('sendNextWave triggered; current wave: ' + gameState.wave);
     startNextWave();
 }
 


### PR DESCRIPTION
## Summary
- log the current wave when manually advancing to the next wave
- log boss spawn events for each wave

## Testing
- `grep -n "sendNextWave triggered" -n index.html`
- `grep -n "boss spawned" -n index.html`


------
https://chatgpt.com/codex/tasks/task_e_6857f37d22fc8322a1f931e6c17b9b1f