### PR TITLE
Add tooltips for extra HUD elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -4156,7 +4156,13 @@ const tooltipTexts = {
   sensorDisplayToggle: 'Switch enemy info mode',
   fullscreenButton: 'Toggle fullscreen',
   muteButton: 'Mute sounds',
-  sendWaveButton: 'Send the next enemy wave'
+  sendWaveButton: 'Send the next enemy wave',
+  creditsDisplay: 'Available credits',
+  waveDisplay: 'Current wave',
+  healthDisplay: 'Base health',
+  hotkeys: 'Keyboard shortcuts',
+  enemyStatsHeader: 'Toggle enemy stats panel',
+  xpStatsHeader: 'Toggle XP status panel'
 };
 Object.entries(tooltipTexts).forEach(([id,text])=>{
   const el=getElement(id);


### PR DESCRIPTION
## Summary
- describe credits, wave, health values with tooltips
- show tooltip help for hotkeys overlay and stats headers

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6857f4b793548322b9ec614b67432684