### PR TITLE
Add syntax check for inline scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+node_modules/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,28 @@
+{
+  "name": "lb-1file",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "lb-1file",
+      "version": "1.0.0",
+      "devDependencies": {
+        "acorn": "^8.11.3"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "lb-1file",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "node scripts/check-scripts.js"
+  },
+  "devDependencies": {
+    "acorn": "^8.11.3"
+  }
+}

--- a/scripts/check-scripts.js
+++ b/scripts/check-scripts.js
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+const acorn = require('acorn');
+
+const htmlPath = path.join(__dirname, '..', 'index.html');
+const html = fs.readFileSync(htmlPath, 'utf8');
+const regex = /<script\b([^>]*)>([\s\S]*?)<\/script>/gi;
+
+const scripts = [];
+let match;
+while ((match = regex.exec(html))) {
+  scripts.push({ attrs: match[1], code: match[2] });
+}
+
+let hasError = false;
+
+scripts.forEach(({ attrs, code }, idx) => {
+  const isModule = /type\s*=\s*["']module["']/.test(attrs);
+  const sourceType = isModule ? 'module' : 'script';
+  try {
+    acorn.parse(code, { ecmaVersion: 'latest', sourceType });
+  } catch (err) {
+    console.error(`Syntax error in script block #${idx + 1}: ${err.message}`);
+    hasError = true;
+  }
+});
+
+if (hasError) {
+  console.error('Script parsing failed.');
+  process.exit(1);
+} else {
+  console.log(`All ${scripts.length} script blocks parsed successfully.`);
+}


### PR DESCRIPTION
## Summary
- add `acorn` and a Node script to check script blocks in `index.html`
- ignore `node_modules`
- wire the script into `npm test`

## Testing
- `npm test` *(fails: Syntax error in script block #3)*

------
https://chatgpt.com/codex/tasks/task_e_6857f9ffddc88322842c33ab85cb6e65