### PR TITLE
Fix sensor intro overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -1840,7 +1840,13 @@ function startGame() {
     getElement('playPauseButton').textContent = '\u25B6'; // Show play icon while paused
     drawGame();
     updateHUD();
-    showSensorWarning();
+    // Show the sensor tutorial only once per browser
+    if (!localStorage.getItem('sensorIntroSeen')) {
+        showSensorWarning();
+        localStorage.setItem('sensorIntroSeen', 'yes');
+    } else {
+        dismissSensorWarning();   // jump straight into the game
+    }
 }
 
 function startDeathSequence() {

--- a/test/test.js
+++ b/test/test.js
@@ -47,7 +47,8 @@ await new Promise((resolve) => {
 
 // Extract required game logic from the HTML
 const showWarnMatch = html.match(/function showSensorWarning\(\)[\s\S]*?\}/);
-const startGameMatch = html.match(/function startGame\(\)[\s\S]*?showSensorWarning\(\);\n\}/);
+// Grab the entire startGame function regardless of internal contents
+const startGameMatch = html.match(/function startGame\(\)[\s\S]*?\n\}/);
 if (!showWarnMatch || !startGameMatch) {
   throw new Error('Required game functions not found');
 }


### PR DESCRIPTION
## Summary
- ensure sensor warning only appears once per browser session
- adjust tests for new startGame logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858a4c7ca3083229e8cd605b342e137