### PR TITLE
Add background music controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,6 +118,10 @@
 <link rel="icon" type="image/x-icon" href="favicon.ico">
 <style>
 :root{--bg-gradient:linear-gradient(135deg,#0f2027,#203a43,#2c5364);--body-bg:#000;--text-color:#fff;--hud-color:#fff;--title-color:#fff;--final-stats-color:#cfab52;--button-bg:#2c220f;--button-text:#e6b54b;--button-border:#e6b54b;--button-hover-bg:#1c1404;--button-disabled-bg:#2f240c;--button-disabled-text:#ac4834;--upgrade-title-color:#e6b54b;--toggle-active-bg:#1c1404;--toggle-active-text:#e6b54b;--toast-bg:rgba(0,0,0,.7);--toast-text:#fff;--switch-bg:#2f240c;--switch-slider-color:#e6b54b;--switch-checked-bg:#1c1404;--switch-label-color:#e6b54b;--stats-border:rgba(230,181,75,.3);--stats-bg:rgba(0,0,0,.4);--hotkey-bg:rgba(0,0,0,.6);--hotkey-text:rgba(230,181,75,.8);--canvas-bg:rgba(0,0,0,.7);--crt-overlay-bg:linear-gradient(rgba(0,0,0,.6) 50%,transparent);--crt-overlay-blend:overlay;--crt-scanline-color:rgba(0,0,0,.1);--crt-vignette:radial-gradient(circle at center,transparent 60%,rgba(0,0,0,.6) 100%);--crt-interlace-color:rgba(0,0,0,.25);--font-family:"Press Start 2P",monospace;--button-font-size:24px;--upgrade-button-font-size:16px;--tab-font-size:14px;--ring-ui-font-size:11px}*{font-family:var(--font-family);box-sizing:border-box;padding:0}*,body{margin:0}body{overflow:hidden;background:var(--body-bg);color:var(--text-color)}#crt-overlay{position:fixed;top:0;left:0;width:100vw;height:100vh;pointer-events:none;z-index:9999;background-image:var(--crt-overlay-bg);background-size:100% 2px;background-blend-mode:var(--crt-overlay-blend)}#gameCanvas{background:var(--canvas-bg);touch-action:none}#gameCanvas,.bg{position:absolute;top:0;left:0}.bg{width:100%;height:100%;background:var(--bg-gradient);z-index:-1}/* HUD must stay above overlay (z-index > 5) */#hud{position:absolute;top:0;left:10px;right:10px;display:flex;justify-content:space-between;align-items:center;font-size:var(--hud-font-size);padding:0;z-index:10;line-height:2;min-height:0;color:var(--hud-color)}#gameOverScreen h1,#startScreen h1{font-size:2rem;text-align:center;overflow:hidden;text-overflow:ellipsis;color:var(--title-color)}#gameOverScreen h1{font-size:5rem;margin-bottom:1rem}#hud span{flex:1;text-align:center;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}#hud #creditsDisplay{text-align:left}#hud #healthDisplay{text-align:right}#gameOverScreen,#highScoreModal,#leaderboard-screen,#sensorWarning,#startScreen,#enemyIdentificationPopup,#howToPlayOverlay{position:absolute;top:0;left:0;right:0;bottom:0;display:flex;flex-direction:column;justify-content:center;align-items:center;background:rgba(0,0,0,.8);text-align:center;z-index:100}#gameOverScreen #finalStats{font-size:2rem;margin-bottom:1.5rem;color:var(--final-stats-color)}button{padding:10px 20px;font-size:var(--button-font-size);line-height:1;margin-top:22px;background:var(--button-bg);color:var(--button-text);border:2px solid var(--button-border);cursor:pointer;transition:all .3s ease}button:hover{background:var(--button-hover-bg);transform:translateY(-2px);box-shadow:0 4px 8px rgba(0,0,0,.2)}button:active{transform:translateY(1px)}button:disabled{background:var(--button-disabled-bg);color:var(--button-disabled-text);cursor:not-allowed;transform:none;box-shadow:none}/* Controls must stay above overlay (z-index > 5) */#controls{position:absolute;bottom:10px;right:10px;display:flex;gap:10px;z-index:10;align-items:center}#toggleInfoButton{width:30px;height:30px;padding:0;border-radius:50%;font-size:20px;line-height:20px}#toggleInfoButton.active{background-color:var(--toggle-active-bg);color:var(--toggle-active-text)}#fullscreenButton,#playPauseButton,#slowDownButton,#speedUpButton{width:30px;height:30px;padding:0;border-radius:50%;font-size:20px;line-height:20px}#speedDisplay{display:flex;align-items:center;justify-content:center;width:40px;font-size:18px}#toast{position:absolute;bottom:20px;left:50%;transform:translateX(-50%);background:var(--toast-bg);color:var(--toast-text);padding:10px 20px;border-radius:20px;z-index:1000;opacity:0;transition:opacity .3s ease;pointer-events:none}#toast.show{opacity:1}.switch{position:relative;display:inline-block;width:50px;height:24px;margin-right:10px}.switch input{opacity:0;width:0;height:0}.slider{cursor:pointer;top:0;left:0;right:0;bottom:0;background-color:var(--switch-bg);border-radius:24px}.slider,.slider:before{position:absolute;transition:.4s}.slider:before{content:"";height:16px;width:16px;left:4px;bottom:4px;background-color:var(--switch-slider-color);border-radius:50%}input:checked+.slider{background-color:var(--switch-checked-bg)}input:checked+.slider:before{transform:translateX(26px)}.switch-label{color:var(--switch-label-color);font-size:16px}.stats{display:flex;justify-content:center;gap:20px;margin-top:10px}.stats div{border:1px solid var(--stats-border);padding:5px 10px;background:var(--stats-bg);border-radius:5px}/* Hotkey panel must stay above overlay (z-index > 5) */#hotkeys{z-index:10;position:absolute;top:60px;right:10px;background:var(--hotkey-bg);padding:5px 10px;border-radius:5px;font-size:var(--hotkey-font-size);color:var(--hotkey-text);display:none}#hotkeys.show{display:block}#sensorToggle{display:flex;align-items:center;gap:5px;font-size:var(--hotkey-font-size);color:var(--hotkey-text);z-index:10}#sensorDisplayToggle{padding:2px 8px;cursor:pointer}#enemyHUD,#sensorDisplayToggle{font-size:var(--hotkey-font-size)}#enemyHUD{position:absolute;top:100px;right:10px;background:var(--hotkey-bg);padding:5px 10px;border-radius:5px;color:var(--hotkey-text);display:none;line-height:1.2;text-align:right;z-index:10;opacity:.9}#enemyHUD.show{display:block}#highScoreTable table{width:80%;margin:0 auto;border-collapse:collapse;font-size:2rem}#highScoreTable td,#highScoreTable th{padding:4px 8px;border-bottom:1px solid var(--button-border);text-align:left}#highScoreTable td{white-space:nowrap}#highScoreTable th{font-weight:700}#highScoreTable td:last-child{text-align:right}.blinking-cursor{font-weight:700;animation:a 1s step-end infinite}@keyframes a{50%{opacity:0}}#highScoreModal input{width:5ch;text-align:center;font-size:24px;background:transparent;color:var(--text-color);border:none;border-bottom:2px solid var(--button-border);outline:none}.crt-scanlines{position:absolute;top:0;left:0;width:100%;height:100%;background:repeating-linear-gradient(0deg,var(--crt-scanline-color),var(--crt-scanline-color) 1px,transparent 0,transparent 2px);pointer-events:none}.crt-container{transform:translateZ(0);position:relative;overflow:hidden}.crt-container:before{background:var(--crt-vignette);z-index:1}.crt-container:after,.crt-container:before{content:"";position:absolute;top:0;left:0;width:100%;height:100%;pointer-events:none}.crt-container:after{background:linear-gradient(hsla(0,6%,7%,0) 50%,var(--crt-interlace-color) 0);background-size:100% 4px;z-index:2}
+#musicControls{display:flex;align-items:center;gap:4px;}
+#trackDisplay{min-width:50px;text-align:center;}
+#musicVolume{writing-mode:bt-lr;-webkit-appearance:slider-vertical;width:8px;height:60px;}
+
 </style>
 <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&family=VT323&family=Share+Tech+Mono&family=Rajdhani&family=Orbitron&display=swap" rel="stylesheet">
 <style>
@@ -149,7 +153,7 @@
 <style>
   @media (max-width: 600px) {
     #hud { font-size: 18px; }
-    #controls button { width: 24px; height: 24px; font-size: 16px; }
+    #controls button { width: 24px; height: 24px; font-size: 16px; margin: 0 2px; }
     #speedDisplay { width: 32px; font-size: 14px; }
   }
 </style>
@@ -226,7 +230,7 @@
         <button id="sensorDisplayToggle">Hud</button>
     </div>
     <button id="fullscreenButton">&#x26F6;</button>
-    <button id="muteButton">&#128266;</button>
+    <div id="musicControls"><button id="prevTrack">&#9664;</button><div id="trackDisplay">Off</div><button id="nextTrack">&#9654;</button><input id="musicVolume" type="range" min="0" max="1" step="0.01"></div>
     <button id="sendWaveButton">Send Next Wave</button>
 </div>
 <div id="hotkeys" class="show">
@@ -766,6 +770,12 @@ const SPEED_STEPS = [0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9,1,1.5,2,3,4,5,6,7,8,9,1
 let speedIndex = SPEED_STEPS.indexOf(1);
 let gameSpeedMultiplier = SPEED_STEPS[speedIndex];
 let isGameRunning = false;
+const musicTracks=["Off","music1.mp3","music2.mp3","music3.mp3","music4.mp3","music5.mp3"];
+let currentTrackIndex=parseInt(localStorage.getItem("ode_musicTrack")||"0",10);
+let musicAudio=new Audio();
+musicAudio.loop=true;
+let musicVolume=parseFloat(localStorage.getItem("ode_musicVolume"))||0.25;
+musicAudio.volume=musicVolume;
 let isMuted = localStorage.getItem('ode_isMuted') === 'true';
 let animationFrameId = null;
 let savedGame = null; // Stores loaded game state
@@ -3711,12 +3721,31 @@ function handleFullscreenChange() {
     drawGame();
 }
 
-function toggleMute() {
-    isMuted = !isMuted;
-    localStorage.setItem('ode_isMuted', isMuted);
-    const btn = getElement('muteButton');
-    btn.textContent = isMuted ? '\uD83D\uDD07' : '\uD83D\uDD0A';
+function setTrack(index){
+    currentTrackIndex=(index+musicTracks.length)%musicTracks.length;
+    localStorage.setItem("ode_musicTrack",currentTrackIndex);
+    playCurrentTrack();
+    updateTrackDisplay();
 }
+
+function playCurrentTrack(){
+    const track=musicTracks[currentTrackIndex];
+    if(track==="Off"){
+        musicAudio.pause();
+    }else{
+        musicAudio.src=track;
+        musicAudio.volume=musicVolume;
+        musicAudio.play();
+    }
+}
+
+function updateTrackDisplay(){
+    const d=getElement("trackDisplay");
+    if(d){
+        d.textContent=currentTrackIndex===0?"Off":`Track ${currentTrackIndex}`;
+    }
+}
+
 
 function updateEnemyHUD(info) {
     const hud = getElement('enemyHUD');
@@ -4153,7 +4182,9 @@ getElement('initialsInput').addEventListener('input', e => {
 });
 getElement('sensorDisplayToggle').onclick = cycleSensorDisplayMode;
 getElement('fullscreenButton').onclick = toggleFullScreen;
-getElement('muteButton').onclick = toggleMute;
+getElement("prevTrack").onclick=()=>setTrack(currentTrackIndex-1);
+getElement("nextTrack").onclick=()=>setTrack(currentTrackIndex+1);
+getElement("musicVolume").oninput=e=>{musicVolume=parseFloat(e.target.value);localStorage.setItem("ode_musicVolume",musicVolume);musicAudio.volume=musicVolume;};
 getElement('sendWaveButton').onclick = sendNextWave;
 
 document.addEventListener('fullscreenchange', handleFullscreenChange);
@@ -4167,7 +4198,9 @@ const tooltipTexts = {
   themeButton: 'Change visual theme',
   sensorDisplayToggle: 'Switch enemy info mode',
   fullscreenButton: 'Toggle fullscreen',
-  muteButton: 'Mute sounds',
+  prevTrack: 'Previous music track',
+  nextTrack: 'Next music track',
+  musicVolume: 'Music volume',
   sendWaveButton: 'Send the next enemy wave'
 };
 Object.entries(tooltipTexts).forEach(([id,text])=>{
@@ -4271,11 +4304,10 @@ function loadAndStartGame() {
     const savedThemeIndex = savedTheme !== null ? parseInt(savedTheme, 10) : 0;
     applyTheme(savedThemeIndex); // Apply saved or default theme
 
-    // Set mute button state
-  const muteBtn = getElement('muteButton');
-  if (muteBtn) {
-    muteBtn.textContent = isMuted ? '\uD83D\uDD07' : '\uD83D\uDD0A';
-  }
+  const volumeSlider = getElement("musicVolume");
+  if(volumeSlider) volumeSlider.value = musicVolume;
+  updateTrackDisplay();
+  playCurrentTrack();
 
 
 


### PR DESCRIPTION
## Summary
- replace mute button with track/volume controls
- style music controls and slider
- implement music track cycling and volume persistence in script
- update tooltips for new controls

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6858c5fc7e808322b7b3d84b0a7e6535