### PR TITLE
Fix audio autoplay issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -1282,6 +1282,7 @@ function showHighScores() {
     getElement('leaderboard-screen').style.display = 'flex';
     getElement('leaderboardLoading').style.display = 'block';
     getElement('deathOverlay').style.display = 'none';
+    playCurrentTrack();
     listenToLeaderboard(renderLeaderboard);
 }
 
@@ -1816,6 +1817,7 @@ function startGame() {
     window.pendingScore = null;
     unlistenLeaderboard();
     initializeGame(true); // Initialize with saved game check
+    playCurrentTrack();
     getElement('startScreen').style.display = 'none';
     getElement('leaderboard-screen').style.display = 'none';
     getElement('gameOverScreen').style.display = 'none';
@@ -4314,7 +4316,6 @@ function loadAndStartGame() {
   const volumeSlider = getElement("musicVolume");
   if(volumeSlider) volumeSlider.value = musicVolume;
   updateTrackDisplay();
-  playCurrentTrack();
 
     updateSpeedDisplay();
 


### PR DESCRIPTION
## Summary
- start music when the player clicks Start Game or Leaderboard
- avoid autoplaying music on page load

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6858caba1ee88322b76156256b44795f