### PR TITLE
Fix wave progression when XP enemies remain

### DIFF
--- a/index.html
+++ b/index.html
@@ -1224,7 +1224,7 @@ function handleEnemyKilled(enemy) {
             if (e.xp) enemyPool.release(e);
         });
     }
-    const enemies = enemyPool.getActiveObjects();
+    const enemies = enemyPool.getActiveObjects().filter(e => !e.xp);
     if (!enemies.some(e => e.wave === enemy.wave)) {
         const idx = activeWaves.indexOf(enemy.wave);
         if (idx !== -1) activeWaves.splice(idx, 1);


### PR DESCRIPTION
## Summary
- adjust `handleEnemyKilled` so XP enemies don't block wave progression

## Testing
- `npx eslint index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858df23ad2883229b4503e32bc3f942