### PR TITLE
Enable automatic next wave after boss

### DIFF
--- a/index.html
+++ b/index.html
@@ -1220,6 +1220,9 @@ function handleEnemyKilled(enemy) {
         if (waveStates[enemy.wave]) {
             waveStates[enemy.wave].bossAlive = false;
         }
+        if (enemy.wave === gameState.wave) {
+            startNextWave();
+        }
         enemyPool.getActiveObjects().forEach(e => {
             if (e.xp) enemyPool.release(e);
         });


### PR DESCRIPTION
## Summary
- trigger the next wave as soon as the current wave's boss dies so gameplay keeps flowing

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6858e0eb2b2083229654095696bdf6e7