### PR TITLE
Fix wave counter not visible until wave ends

### DIFF
--- a/index.html
+++ b/index.html
@@ -1243,11 +1243,8 @@ function handleEnemyKilled(enemy) {
             waveStates[enemy.wave].remainingEnemies--;
         }
     }
-    const enemies = enemyPool.getActiveObjects().filter(e => !e.xp);
-    if (!enemies.some(e => e.wave === enemy.wave)) {
-        const idx = activeWaves.indexOf(enemy.wave);
-        if (idx !== -1) activeWaves.splice(idx, 1);
-    }
+    // Keep wave in the active list until completion so the HUD counter
+    // properly counts down to 0/0 before the next wave begins
     updateHUD();
 }
 


### PR DESCRIPTION
## Summary
- ensure active waves stay tracked until wave completion

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6858fa9afb9c8322a6a8260417c8f29b