### PR TITLE
Fix leaderboard scoring for multi-wave queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Orbital Defence Elite - Change Log
 
+## v2.43
+- Leaderboard now uses the earliest active wave on death to prevent inflated
+  scores when multiple waves are queued.
+
 ## v2.42
 - Info upgrade uses a standalone layout without connecting lines.
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,10 @@ similar to the example below:
 }
 ```
 
-Scores are ranked using the formula `ranking = wave * 100000 - time`. Higher waves and faster completion times result in a higher leaderboard position.
+Scores are ranked using the formula `ranking = wave * 100000 - time` where
+`wave` is the lowest wave that was still active when the player was defeated.
+This ensures sending multiple waves early will not inflate scores. Higher waves
+and faster completion times result in a better leaderboard position.
 
 The database must allow writes at `/scores` so the game can submit new
 entries. A `permission_denied` error in the browser console typically means the

--- a/index.html
+++ b/index.html
@@ -1886,9 +1886,16 @@ function gameOver() {
     getElement('deathOverlay').style.display = 'block';
     const survivalTime = Math.floor((Date.now() - gameStartTime) / 1000);
     getElement('finalStats').textContent = `Wave ${gameState.wave}/${survivalTime}s - ${formatDate(new Date())}`;
-    const remainingTime = completedWaves[completedWave] ?? 0;
-    const playerRank = completedWave * 100000 - remainingTime;
-    window.pendingScore = { wave: completedWave, time: remainingTime, ranking: playerRank, saved: false };
+    const scoreWave = activeWaves.length > 0
+        ? Math.min(...activeWaves)
+        : completedWave + 1;
+    let remainingTime = completedWaves[scoreWave] ?? 0;
+    const state = waveStates[scoreWave];
+    if (state) {
+        remainingTime = Math.floor(Math.max(0, state.duration - state.elapsedTime));
+    }
+    const playerRank = scoreWave * 100000 - remainingTime;
+    window.pendingScore = { wave: scoreWave, time: remainingTime, ranking: playerRank, saved: false };
     getTopScores().then(scores => {
         let index = scores.findIndex(s => playerRank > s.ranking);
         if (index === -1 && scores.length < 10) index = scores.length;


### PR DESCRIPTION
## Summary
- compute leaderboard ranking based on earliest unfinished wave
- document how wave ranking works in README
- note leaderboard fix in changelog

## Testing
- `npm test` *(fails: ENOENT: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6859f5db7f5c8322a95f2e62b1026fc5