### PR TITLE
Allow adjusting speed while paused

### DIFF
--- a/HOW_TO_PLAY.md
+++ b/HOW_TO_PLAY.md
@@ -8,6 +8,7 @@
 - **Move Base:** Drag with the mouse or use the **WASD** or **Arrow** keys.
 - **Fire:** The cannon automatically shoots when enemies are in range. Press **F** to toggle auto-fire or use the **Space** key when auto-fire is disabled.
 - **Macross Missiles:** Press **M** to unleash a barrage of missiles once the upgrade is unlocked.
+- **Game Speed:** Use the **«** and **»** buttons to adjust how fast the game runs. You can change the speed even while paused.
 - **Upgrades:** Click the base to open the upgrade ring. You can also click directly on an upgrade icon within the ring for quick access.
 - **Interface Toggles:**
   - **H** – show or hide the hotkeys list.

--- a/index.html
+++ b/index.html
@@ -1432,9 +1432,6 @@ function pauseGame() {
 
 function resumeGame() {
     if (isGameRunning) return;
-    gameSpeedMultiplier = 1;
-    speedIndex = SPEED_STEPS.indexOf(1);
-    updateSpeedDisplay();
     isGameRunning = true;
     lastTime = 0;
     animationFrameId = requestAnimationFrame(gameLoop);
@@ -4339,7 +4336,6 @@ getElement('playPauseButton').onclick = () => {
     }
 };
 getElement('slowDownButton').onclick = () => {
-    if (!isGameRunning) return;
     if (speedIndex > 0) {
         speedIndex--;
         gameSpeedMultiplier = SPEED_STEPS[speedIndex];
@@ -4347,7 +4343,6 @@ getElement('slowDownButton').onclick = () => {
     }
 };
 getElement('speedUpButton').onclick = () => {
-    if (!isGameRunning) return;
     if (speedIndex < SPEED_STEPS.length - 1) {
         speedIndex++;
         gameSpeedMultiplier = SPEED_STEPS[speedIndex];


### PR DESCRIPTION
## Summary
- let users change game speed when the game is paused
- keep current speed when resuming
- document the speed controls

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685a3f4dabd88322b58afe5a66db552a