### PR TITLE
Fix wave shown on provisional leaderboard row

### DIFF
--- a/index.html
+++ b/index.html
@@ -1935,7 +1935,12 @@ function gameOver() {
         if (index === -1 && scores.length < 10) index = scores.length;
         let list = scores.slice();
         if (index !== -1) {
-            list.splice(index, 0, { initials: '???', wave: completedWave, time: remainingTime, date: formatDate(new Date()) });
+            list.splice(index, 0, {
+                initials: '???',
+                wave: scoreWave,
+                time: remainingTime,
+                date: formatDate(new Date())
+            });
             list = list.slice(0, 10);
         }
         renderScoreList('gameOverScoreList', list, index);


### PR DESCRIPTION
## Summary
- show the correct wave number for pending score placement

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685a5b175c6c83229ec77403047af9cf