### PR TITLE
Adjust enemy stats panel width

### DIFF
--- a/index.html
+++ b/index.html
@@ -168,7 +168,7 @@
   @keyframes slowBlink { 50% { opacity: 0; } }
   .sub-message { margin-bottom: 1rem; color: var(--button-text); }
   .overlay-desaturate { position: absolute; inset: 0; background: rgba(0,0,0,0.5); backdrop-filter: grayscale(1); pointer-events: none; z-index: 99; }
-  #enemyStatsPanel { position: absolute; right: 10px; background: var(--hotkey-bg); padding: 5px 10px; border-radius: 5px; font-size: var(--hotkey-font-size); color: var(--hotkey-text); z-index: 10; word-wrap: break-word; }
+  #enemyStatsPanel { position: absolute; right: 10px; background: var(--hotkey-bg); padding: 5px 10px; border-radius: 5px; font-size: var(--hotkey-font-size); color: var(--hotkey-text); z-index: 10; word-wrap: break-word; width: 100px; }
   #enemyStatsPanel.collapsed #enemyStatsContent { display: none; }
   #enemyStatsHeader { cursor: pointer; }
   #enemyStatsHeader .arrow { margin-left: 4px; }
@@ -3933,8 +3933,8 @@ function updateEnemyStatsPanel(){
     if(hotkeysWidth===null){
         hotkeysWidth=hotkeys.offsetWidth;
     }
-    panel.style.width="";
-    panel.style.maxWidth=hotkeysWidth+"px";
+    panel.style.width="100px";
+    panel.style.maxWidth="100px";
     let top=hudBar.offsetHeight+10;
     if(hotkeys.classList.contains("show")) top+=hotkeys.offsetHeight+10;
     panel.style.top=top+"px";


### PR DESCRIPTION
## Summary
- keep enemy stats panel width fixed at 100px so overflow text wraps inside

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685cf77f046083229893bf05887671d6