### PR TITLE
Add MIDI background track

### DIFF
--- a/HOW_TO_PLAY.md
+++ b/HOW_TO_PLAY.md
@@ -15,9 +15,9 @@
   - **I** – display detailed enemy statistics.
   - **O** – toggle ring upgrade information.
   - **Full Screen** and **Mute** buttons are available on the HUD.
-  - **Music:** use the arrow buttons to cycle through tracks. The slider next
-    to the selector controls volume, starting at 25%. Choose **Off** to disable
-    the background music.
+  - **Music:** use the arrow buttons to cycle through tracks, including
+    the new *Track One MIDI*. The slider next to the selector controls
+    volume, starting at 25%. Choose **Off** to disable the background music.
 
 ## Surviving Waves
 Each wave spawns a group of enemies that approach from beyond your sensor range. The faint ring around your base shows the cannon's firing radius. Upgrade the **Sensors** category to detect enemies earlier. Destroy enemies to earn credits and purchase new abilities.

--- a/index.html
+++ b/index.html
@@ -113,6 +113,8 @@
     renderLeaderboard(scores, idx);
     });
 </script>
+<script src="https://cdn.jsdelivr.net/npm/midi-player-js@2.0.5/build/MidiPlayer.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/soundfont-player@0.15.1/dist/soundfont-player.min.js"></script>
 
 <title>Orbital Defense v2.45 - Optimised</title>
 <link rel="icon" type="image/x-icon" href="favicon.ico">
@@ -840,10 +842,14 @@ const SPEED_STEPS = [0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9,1,1.5,2,3,4,5,6,7,8,9,1
 let speedIndex = SPEED_STEPS.indexOf(1);
 let gameSpeedMultiplier = SPEED_STEPS[speedIndex];
 let isGameRunning = false;
-const musicTracks=["Off","music1.mp3","music2.mp3","music3.mp3","music4.mp3","music5.mp3"];
+const musicTracks=["Off","music1.mp3","music2.mp3","music3.mp3","music4.mp3","music5.mp3","music1.mid"];
+const musicTrackNames=["Off","Track 1","Track 2","Track 3","Track 4","Track 5","Track One MIDI"];
 let currentTrackIndex=parseInt(localStorage.getItem("ode_musicTrack")||"0",10);
 let musicAudio=new Audio();
 musicAudio.loop=true;
+let midiPlayer=null;
+let midiInstrument=null;
+let audioContext=null;
 let musicVolume=parseFloat(localStorage.getItem("ode_musicVolume"))||0.25;
 musicAudio.volume=musicVolume;
 let isMuted = localStorage.getItem('ode_isMuted') === 'true';
@@ -1026,6 +1032,26 @@ function resetMissile(missile, config) {
         missile.startY = 0;
         missile.rangeLimit = base.missileTargetingRadius * 1.1;
     }
+}
+
+async function playMidiTrack(src){
+    if(!audioContext){
+        audioContext=new (window.AudioContext||window.webkitAudioContext)();
+    }
+    if(!midiInstrument){
+        midiInstrument=await Soundfont.instrument(audioContext,'acoustic_grand_piano');
+    }
+    if(midiPlayer){
+        midiPlayer.stop();
+    }
+    midiPlayer=new MidiPlayer.Player(event=>{
+        if(event.name==='Note on'){
+            midiInstrument.play(event.noteName,audioContext.currentTime,{gain:musicVolume});
+        }
+    });
+    const buf=await fetch(src).then(r=>r.arrayBuffer());
+    midiPlayer.loadArrayBuffer(buf);
+    midiPlayer.play();
 }
 
 
@@ -3927,16 +3953,20 @@ function playCurrentTrack(){
     if(track==="Off"){
         musicAudio.pause();
     }else{
-        musicAudio.src=track;
-        musicAudio.volume=musicVolume;
-        musicAudio.play();
+        if(track.toLowerCase().endsWith('.mid')){
+            playMidiTrack(track);
+        }else{
+            musicAudio.src=track;
+            musicAudio.volume=musicVolume;
+            musicAudio.play();
+        }
     }
 }
 
 function updateTrackDisplay(){
     const d=getElement("trackDisplay");
     if(d){
-        d.textContent=currentTrackIndex===0?"Off":`Track ${currentTrackIndex}`;
+        d.textContent=musicTrackNames[currentTrackIndex]||`Track ${currentTrackIndex}`;
     }
 }
 


### PR DESCRIPTION
## Summary
- add `music1.mid` to music track list and name it Track One MIDI
- load MIDI player scripts
- implement MIDI playback logic with Soundfont
- document new track in HOW_TO_PLAY

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68762b75aa648322bb48e754dd63f0ad