### PR TITLE
Ensure canvas center on resize

### DIFF
--- a/index.html
+++ b/index.html
@@ -4471,10 +4471,16 @@ window.addEventListener('resize', () => {
     canvasHeight = window.innerHeight;
     canvas.width = canvasWidth;
     canvas.height = canvasHeight;
-    // No need to reposition DOM elements anymore
-    // Re-applying certain base stats that depend on screen size might be needed
-    // e.g., if stun radius or laser range were calculated differently based on resize.
-    // For now, assume fixed calculation or recalculation within applyUpgradeEffect.
+    if (fogCanvas) {
+        fogCanvas.width = canvasWidth;
+        fogCanvas.height = canvasHeight;
+    }
+    if (base) {
+        base.x = canvasWidth / 2;
+        base.y = canvasHeight / 2;
+        baseStartX = base.x;
+        baseStartY = base.y;
+    }
     if (isGameRunning) {
         drawGame(); // Redraw immediately after resize
     }


### PR DESCRIPTION
## Summary
- adjust resize handler to reset canvas size
- center the player base and update fog canvas whenever window size changes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6879d90da0e08322973241b56466ac02