### PR TITLE
Set black and white theme base to black

### DIFF
--- a/index.html
+++ b/index.html
@@ -561,7 +561,7 @@ const THEMES = [
             '--hotkey-font-size': '12px'
         },
         canvasColors: {
-            base: '#333333',
+            base: '#000000',
             baseHit: '#000000',
             bullet: '#000000',
             missile: '#333333',


### PR DESCRIPTION
## Summary
- set the base color to pure black in the "Pixel Black and White" theme

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6881d9cd8cf88322a599f4990e6e624d