### PR TITLE
Improve pixel B&W upgrade text visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -592,8 +592,8 @@ const THEMES = [
             ringSensor: 'rgba(255, 200, 0, 0.6)',
             ringUpgradeBoxBg: 'rgba(200, 200, 200, 0.7)',
             ringUpgradeBoxAvailable: 'rgba(0, 255, 0, 0.7)',
-            ringUpgradeBoxText: '#646464',
-            ringUpgradeBoxMax: '#333333',
+            ringUpgradeBoxText: '#000000',
+            ringUpgradeBoxMax: '#000000',
             gunBarrel: '#000000',
             baseDragIndicator: 'rgba(50, 50, 50, 0.6)',
             baseReturnIndicator: 'rgba(100, 100, 100, 0.6)'


### PR DESCRIPTION
## Summary
- tweak pixel black and white theme so upgrade boxes use same text color as control buttons

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6881ee6a935883229a98cbbd08e7ef9b