### PR TITLE
Fix dark text for pixel theme parent upgrades

### DIFF
--- a/index.html
+++ b/index.html
@@ -3315,7 +3315,10 @@ function drawCollapsibleUpgradeElement(x, y, title, category, categoryIndex, isE
         ctx.fillRect(x, y, boxWidth, headerHeight);
     }
 
-    ctx.fillStyle = hasAvailable ? '#00ff00' : color;
+    const headerTextColor = currentTheme.name === 'Pixel Black and White'
+        ? (currentTheme.canvasColors.ringUpgradeBoxText || '#000')
+        : (hasAvailable ? '#00ff00' : color);
+    ctx.fillStyle = headerTextColor;
     ctx.fillText(title, x + padding, y + padding);
     ctx.textAlign = 'right';
     ctx.fillText(isExpanded ? '-' : '+', x + boxWidth - padding, y + padding);


### PR DESCRIPTION
## Summary
- use new header text color logic for collapsible upgrade buttons in Pixel Black and White theme

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6881f1d3a57483229b9d4ecb4f23f7ba