### PR TITLE
Add SFX toggle button to enable/disable beep sound effects

### DIFF
--- a/index.html
+++ b/index.html
@@ -340,7 +340,7 @@
     </div>
     <button id="fullscreenButton">&#x26F6;</button>
 
-    <div id="musicControls"><button id="prevTrack">&#9664;</button><div id="trackDisplay">Off</div><button id="nextTrack">&#9654;</button><input id="musicVolume" type="range" min="0" max="1" step="0.01"></div>
+    <div id="musicControls"><button id="prevTrack">&#9664;</button><div id="trackDisplay">Off</div><button id="nextTrack">&#9654;</button><button id="sfxToggleButton">SFX: On</button><input id="musicVolume" type="range" min="0" max="1" step="0.01"></div>
 
     <button id="sendWaveButton">Send Next Wave</button>
 </div>
@@ -1127,6 +1127,7 @@ let musicAudio=new Audio();
 musicAudio.loop=true;
 let musicVolume=parseFloat(localStorage.getItem("ode_musicVolume"))||0.25;
 musicAudio.volume=musicVolume;
+let sfxEnabled = localStorage.getItem("ode_sfxEnabled") !== "false";
 let isMuted = localStorage.getItem('ode_isMuted') === 'true';
 let animationFrameId = null;
 let savedGame = null; // Stores loaded game state
@@ -4419,7 +4420,13 @@ function toggleWaveStatsPanel(){
     updateWaveStatsPanel();
 }
 
+function updateSfxButton(){
+    const b=getElement("sfxToggleButton");
+    if(b) b.textContent=`SFX: ${sfxEnabled ? "On" : "Off"}`;
+}
+
 function beep(){
+    if(!sfxEnabled) return;
     try{const c=new(window.AudioContext||window.webkitAudioContext)();const o=c.createOscillator();o.type="square";o.frequency.value=800;o.connect(c.destination);o.start();setTimeout(()=>{o.stop();c.close();},100);}catch(e){}
 }
 
@@ -4785,6 +4792,11 @@ getElement('fullscreenButton').onclick = toggleFullScreen;
 getElement("prevTrack").onclick=()=>setTrack(currentTrackIndex-1);
 getElement("nextTrack").onclick=()=>setTrack(currentTrackIndex+1);
 getElement("musicVolume").oninput=e=>{musicVolume=parseFloat(e.target.value);localStorage.setItem("ode_musicVolume",musicVolume);musicAudio.volume=musicVolume;};
+getElement("sfxToggleButton").onclick=()=>{
+    sfxEnabled=!sfxEnabled;
+    localStorage.setItem("ode_sfxEnabled",String(sfxEnabled));
+    updateSfxButton();
+};
 
 getElement('sendWaveButton').onclick = sendNextWave;
 
@@ -4806,6 +4818,7 @@ const tooltipTexts = {
   prevTrack: 'Previous music track',
   nextTrack: 'Next music track',
   musicVolume: 'Music volume',
+  sfxToggleButton: 'Toggle beep sound effects',
 
   sendWaveButton: 'Send the next enemy wave'
 };
@@ -4945,6 +4958,7 @@ function loadAndStartGame() {
   const volumeSlider = getElement("musicVolume");
   if(volumeSlider) volumeSlider.value = musicVolume;
   updateTrackDisplay();
+  updateSfxButton();
 
     updateSpeedDisplay();
 


### PR DESCRIPTION
### Motivation
- Provide players a way to turn in-game beep sound effects on or off independently from music. 
- Prevent unwanted beep audio during enemy-identification popups and other short UI cues. 
- Persist the player preference across sessions so SFX state is remembered.

### Description
- Added an `SFX: On/Off` button to the HUD music controls in `index.html` (`#sfxToggleButton`).
- Introduced a `sfxEnabled` flag read from `localStorage` (`ode_sfxEnabled`) with a default of enabled and wired a `getElement` click handler to toggle and persist it.
- Added `updateSfxButton()` to keep the button label in sync and called it during startup initialization.
- Modified `beep()` to return early when `sfxEnabled` is false so beep sounds obey the new toggle, and added a tooltip entry for the new control.

### Testing
- Searched the codebase for the new identifiers with `rg` to verify wiring (`sfxToggleButton`, `sfxEnabled`, `updateSfxButton`, `function beep`) and the search completed successfully.
- Inspected the change with `git diff`/line-numbered views of `index.html` to confirm only intended insertions and replacements were made, which succeeded.
- Verified the new button and initialization call appear in the loaded file via `nl`/file excerpts, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a163e2a4fa08322b6611ae414ec1bf6)