### PR TITLE
Style inline enemy HUD cards to match ring info display

### DIFF
--- a/index.html
+++ b/index.html
@@ -3260,27 +3260,49 @@ function drawGame() {
             if (sensorUpgrades.showHealthBars) boxHeight += barHeight + fontSize + 8;
             const boxX = enemy.x + bracketSize + 10;
             const boxY = enemy.y - boxHeight / 2;
-            ctx.fillStyle = 'rgba(255,204,0,0.35)';
+            // Match inline enemy cards to the ring info display style
+            ctx.fillStyle = 'rgba(2, 14, 20, 0.55)';
             ctx.fillRect(boxX, boxY, boxWidth, boxHeight);
-            ctx.strokeStyle = '#ffcc00';
+            ctx.strokeStyle = 'rgba(0, 255, 230, 0.45)';
+            ctx.lineWidth = 1;
+            ctx.strokeRect(boxX, boxY, boxWidth, boxHeight);
+
+            // Connector line (same color family as ring info display)
+            ctx.strokeStyle = 'rgba(0, 255, 230, 0.6)';
             ctx.beginPath();
             ctx.moveTo(enemy.x + bracketSize, enemy.y);
             ctx.lineTo(boxX, boxY + 10);
             ctx.stroke();
+
+            // Corner brackets (retro HUD accent)
+            const bracketLength = 6;
+            const inset = 1;
+            const left = boxX + inset;
+            const right = boxX + boxWidth - inset;
+            const top = boxY + inset;
+            const bottom = boxY + boxHeight - inset;
+            ctx.strokeStyle = 'rgba(0, 255, 230, 0.95)';
+            ctx.lineWidth = 1.5;
+            ctx.beginPath();
+            ctx.moveTo(left, top + bracketLength); ctx.lineTo(left, top); ctx.lineTo(left + bracketLength, top);
+            ctx.moveTo(right - bracketLength, top); ctx.lineTo(right, top); ctx.lineTo(right, top + bracketLength);
+            ctx.moveTo(left, bottom - bracketLength); ctx.lineTo(left, bottom); ctx.lineTo(left + bracketLength, bottom);
+            ctx.moveTo(right - bracketLength, bottom); ctx.lineTo(right, bottom); ctx.lineTo(right, bottom - bracketLength);
+            ctx.stroke();
             let textY;
             if (sensorUpgrades.showHealthBars) {
-                ctx.fillStyle = '#664400';
+                ctx.fillStyle = 'rgba(0, 255, 230, 0.2)';
                 ctx.fillRect(boxX + padding, boxY + padding, boxWidth - padding * 2, barHeight);
-                ctx.fillStyle = '#ffcc00';
+                ctx.fillStyle = 'rgba(0, 255, 230, 0.9)';
                 ctx.fillRect(boxX + padding, boxY + padding, (boxWidth - padding * 2) * healthPercent, barHeight);
-                ctx.fillStyle = '#000';
+                ctx.fillStyle = 'rgba(210, 255, 250, 0.95)';
                 ctx.font = '8px monospace';
                 ctx.fillText('HP', boxX + padding, boxY + padding + barHeight + fontSize - 1);
                 textY = boxY + padding + barHeight + fontSize + 4;
             } else {
                 textY = boxY + padding + fontSize;
             }
-            ctx.fillStyle = '#000';
+            ctx.fillStyle = 'rgba(210, 255, 250, 0.95)';
             infoLines.forEach(t => { ctx.fillText(t, boxX + padding, textY); textY += fontSize + 2; });
         } else {
             if (sensorUpgrades.showHealthBars) {


### PR DESCRIPTION
### Motivation
- Unify the visual language between the inline enemy HUD and the ring information panels so enemy info feels consistent with the ring-style O display and improves legibility.

### Description
- Updated inline enemy info rendering in `index.html` to use a dark translucent panel and cyan/teal border that matches the ring info display and set `lineWidth` for consistent stroke weight.
- Replaced the old yellow card treatment with a connector line in the ring-info color family and added retro corner bracket accents to mirror ring panels.
- Adjusted HP bar fill/background and text colors for the inline cards to the same cyan/scanline palette and ensured text uses the ring-style readable color.

### Testing
- No automated tests exist in this repository, so no automated test runs were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a163e98d6c48322a3b7b2735f72d640)