### PR TITLE
Preserve canvas state and fix inline enemy info text alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -3236,6 +3236,9 @@ function drawGame() {
         const barY = enemy.y - (sensorUpgrades.enemyVisuals ? enemy.radius : 4) - barYOffset;
 
         if (sensorDisplayMode === 'inline') {
+            ctx.save();
+            ctx.textAlign = 'left';
+            ctx.textBaseline = 'alphabetic';
             const inlineAccent = getCategoryColor(UPGRADE_CATEGORY_INFO);
             const inlineText = currentTheme.canvasColors.ringUpgradeBoxText || '#e6b54b';
             const inlineBg = currentTheme.canvasColors.ringUpgradeBoxBg || currentTheme.canvasColors.hotkeyBg || 'rgba(0,0,0,0.6)';
@@ -3308,6 +3311,7 @@ function drawGame() {
             }
             ctx.fillStyle = 'rgba(210, 255, 250, 0.95)';
             infoLines.forEach(t => { ctx.fillText(t, boxX + padding, textY); textY += fontSize + 2; });
+            ctx.restore();
         } else {
             if (sensorUpgrades.showHealthBars) {
                 ctx.fillStyle = '#664400';


### PR DESCRIPTION
### Motivation
- Inline enemy info text could inherit global canvas text alignment from other draw paths, causing lines to render outside the info card bounds and produce overflow artifacts.

### Description
- Wrap the inline enemy info draw block in `ctx.save()` / `ctx.restore()` so temporary canvas state changes do not leak to other drawing code.
- Explicitly set `ctx.textAlign = 'left'` and `ctx.textBaseline = 'alphabetic'` before measuring and drawing the inline enemy stats inside `drawGame()`.

### Testing
- Ran `git diff -- index.html` to verify the `ctx.save()`/`ctx.restore()` and alignment changes were applied successfully.
- Committed the change with `git add` and `git commit -m "Fix inline enemy stat text alignment in info cards"` which completed without error.
- Inspected the updated file region with `nl -ba index.html | sed -n '3232,3320p'` to confirm the new lines are present and in the expected location.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16473b982883229bdc4f040d26a974)