### PR TITLE
Replace hardcoded 'Hannah' label with generic identification text and clarify upgrade prompt

### DIFF
--- a/index.html
+++ b/index.html
@@ -3244,8 +3244,8 @@ function drawGame() {
             const inlineBg = currentTheme.canvasColors.ringUpgradeBoxBg || currentTheme.canvasColors.hotkeyBg || 'rgba(0,0,0,0.6)';
             const infoLines = [];
             if (!sensorUpgrades.enemyVisuals) {
-                infoLines.push('Hannah Undefined');
-                infoLines.push('Upgrade the Sensor Array');
+                infoLines.push('Unidentified Object');
+                infoLines.push('Upgrade Identification Sensors');
             } else {
                 infoLines.push(enemy.type);
                 infoLines.push(`Speed: ${enemy.speed.toFixed(1)}`);


### PR DESCRIPTION
### Motivation
- Replace a misleading/hardcoded inline label and make the sensor upgrade prompt clearer so unidentified enemies are described generically and upgrade messaging is more descriptive.

### Description
- In `index.html` inside `drawGame()` the inline `infoLines` text for unidentified enemies was changed from `"Hannah Undefined"` to `"Unidentified Object"` and `"Upgrade the Sensor Array"` to `"Upgrade Identification Sensors"`.

### Testing
- No automated tests were run for this trivial UI text change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a164cf4ac2883228684f8d9c236574d)