### PR TITLE
Remove redundant 'HP' label from inline enemy HUD

### DIFF
--- a/index.html
+++ b/index.html
@@ -3304,7 +3304,6 @@ function drawGame() {
                 ctx.fillRect(boxX + padding, boxY + padding, (boxWidth - padding * 2) * healthPercent, barHeight);
                 ctx.fillStyle = 'rgba(210, 255, 250, 0.95)';
                 ctx.font = '10px monospace';
-                ctx.fillText('HP', boxX + padding, boxY + padding + barHeight + fontSize - 1);
                 textY = boxY + padding + barHeight + fontSize + 4;
             } else {
                 textY = boxY + padding + fontSize;


### PR DESCRIPTION
### Motivation
- The inline enemy info card displayed a separate `HP` text label under the health bar which overlapped with the enemy name and duplicated information, so the UI should only show the health bar and enemy details.

### Description
- Removed the single draw call `ctx.fillText('HP', boxX + padding, boxY + padding + barHeight + fontSize - 1);` from the inline sensor/card rendering in `index.html` so the health bar remains but the standalone `HP` label is no longer rendered.

### Testing
- No automated tests were run for this visual text-rendering tweak.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a164f2c8b548322a8c22a84912c7dcd)