### PR TITLE
Fix ring info layering and cannon targeting label

### DIFF
--- a/index.html
+++ b/index.html
@@ -371,7 +371,7 @@
   </div>
 </div>
 <div id="sensorWarning" style="display:none">
-    <p>The ring around your base shows your cannon's visual firing range. The cannon cannot target enemies beyond this radius. Click on the "Cannon" to upgrade the cannon's abilities.</p>
+    <p>The ring around your base shows your cannon's targeting range. The cannon cannot target enemies beyond this radius. Click on the "Cannon" to upgrade the cannon's abilities.</p>
     <p>Upgrade "Sensors" Electronic FOV to see enemies outside this ring. The wave timer has started – enemies approach from beyond your sight.</p>
     <button id="sensorWarningButton">Continue</button>
 </div>
@@ -3066,7 +3066,7 @@ function drawGame() {
     // Display simple pop-up panels describing each ring when ring info is enabled
     if (showRingInfo) {
         let offset = 0;
-        drawRingInfoPanel(base.cannonRange, 'Cannon Range', offset++);
+        drawRingInfoPanel(base.cannonRange, 'Cannon Targeting Range', offset++);
         if (base.missileCount > 0 && base.missileTargetingRadius > 0) {
             drawRingInfoPanel(base.missileTargetingRadius, 'Missile Range', offset++);
         }
@@ -3402,28 +3402,6 @@ function drawGame() {
     drawParticles();
 
     applyOverlay(visibleRadius);
-
-    // Display simple pop-up panels describing each ring when ring info is enabled
-    if (showRingInfo) {
-        let offset = 0;
-        drawRingInfoPanel(base.cannonRange, 'Cannon Range', offset++);
-        if (base.missileCount > 0 && base.missileTargetingRadius > 0) {
-            drawRingInfoPanel(base.missileTargetingRadius, 'Missile Range', offset++);
-        }
-        if (base.laserDamage > 0 && base.laserRange > 0) {
-            drawRingInfoPanel(base.laserRange, 'Laser Range', offset++);
-        }
-        if (base.stunLevel > 0 && base.stunRadius > 0) {
-            drawRingInfoPanel(base.stunRadius, 'Stun Radius', offset++);
-        }
-        if (base.sensorRange > base.cannonRange) {
-            drawRingInfoPanel(base.sensorRange, 'Sensor Range', offset++);
-        }
-        if (base.focusRadiusSetting > 0) {
-            drawRingInfoPanel(base.cannonRange * base.focusRadiusSetting, 'Focus Radius', offset++);
-        }
-    }
-
     // --- Draw Ring UI (Directly on Canvas) ---
     ringClickRegions = []; // Clear regions each frame
 


### PR DESCRIPTION
### Motivation
- Ring UI labels described the cannon as a visual firing range rather than its targeting range, which was misleading relative to gameplay. 
- Ring identifiers were rendered in a later pass and thus appeared above incoming enemies, causing Z-order/visibility issues.

### Description
- Renamed the cannon ring label from `Cannon Range` to `Cannon Targeting Range` in the ring info panels and updated the in-page help text to match the intended meaning. 
- Removed the duplicated `showRingInfo` draw pass that occurred after `applyOverlay(visibleRadius)`, ensuring ring info is drawn earlier so identifiers render underneath enemies. 
- Kept all gameplay values unchanged; this is strictly a rendering-order and labeling fix in `index.html`.

### Testing
- Searched the codebase for related labels and render logic using `rg` to confirm occurrences of `Cannon Targeting Range`, `showRingInfo`, and `applyOverlay(visibleRadius)` were updated; the commands completed successfully. 
- Verified the modified file with `git status` and committed the change via `git commit`, which succeeded. 
- No unit tests exist for rendering; manual/visual verification is expected during runtime to confirm ring identifiers now appear underneath enemies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16511b24cc8322957444278f190453)