### PR TITLE
Render fog overlay before tactical rings/HUD so rings and inline info remain visible

### DIFF
--- a/index.html
+++ b/index.html
@@ -3017,6 +3017,9 @@ function drawGame() {
         base.stunRadius
     );
 
+    // Draw the dark sensor shadow first so tactical overlays stay readable above it.
+    applyOverlay(visibleRadius);
+
     // --- Draw Range Rings ---
     ctx.lineWidth = 2;
     // Cannon Range
@@ -3401,7 +3404,6 @@ function drawGame() {
     // --- Draw Particles ---
     drawParticles();
 
-    applyOverlay(visibleRadius);
     // --- Draw Ring UI (Directly on Canvas) ---
     ringClickRegions = []; // Clear regions each frame
 


### PR DESCRIPTION
### Motivation
- The dark sensor/fog overlay was being drawn after tactical elements, which dimmed cannon targeting rings and inline HUD/ring info making them hard to read.
- The intended stacking is to have the fog shadow underneath ring UI and HUD but still beneath enemies and their targeting indicators.

### Description
- Moved the `applyOverlay(visibleRadius)` call into `drawGame()` immediately after computing `visibleRadius` so the fog is drawn before range rings and ring UI.
- Removed the later `applyOverlay(visibleRadius)` invocation at the end of the main draw path to avoid re-darkening already-drawn tactical overlays.
- Preserved draw order so enemies and their targeting overlays are still rendered after range/ring layers and remain on top.

### Testing
- Verified the change by searching for the overlay placement with `rg -n "applyOverlay\(|Draw the dark sensor shadow" index.html` and confirming the new insertion.
- Inspected the modified regions with `nl -ba index.html | sed -n '3010,3040p;3450,3490p'` to confirm the early overlay call and removal of the late call.
- Committed the update successfully with `git commit`, with no runtime test suite available in the repository.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1653cfd600832297a111d106c2caf3)