### PR TITLE
Rename Service HUD theme to Neon and improve HUD visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -659,13 +659,13 @@ const THEMES = [
             cyan: ['#333333', '#777777']
         }
     },
-    { // Theme 5: Service HUD
-        name: "Service HUD",
+    { // Theme 5: Neon HUD
+        name: "Neon",
         cssVariables: {
             '--bg-gradient': '#0a0f13',
             '--body-bg': '#0a0f13',
             '--text-color': '#e2eaf3',
-            '--hud-color': '#64f58d',
+            '--hud-color': '#00ffe1',
             '--title-color': '#00ffe1',
             '--final-stats-color': '#f3c400',
             '--button-bg': '#1b2a33',
@@ -688,11 +688,11 @@ const THEMES = [
             '--hotkey-bg': 'rgba(255,255,255,0.06)',
             '--hotkey-text': '#8899a6',
             '--canvas-bg': '#0a0f13',
-            '--crt-overlay-bg': 'linear-gradient(rgba(0,255,255,0.06) 50%, transparent 100%)',
+            '--crt-overlay-bg': 'linear-gradient(rgba(0,255,255,0.03) 50%, transparent 100%)',
             '--crt-overlay-blend': 'overlay',
-            '--crt-scanline-color': 'rgba(255, 255, 255, 0.05)',
+            '--crt-scanline-color': 'rgba(255, 255, 255, 0.02)',
             '--crt-vignette': 'radial-gradient(circle, transparent 60%, rgba(0,0,0,0.5) 100%)',
-            '--crt-interlace-color': 'rgba(255, 255, 255, 0.05)',
+            '--crt-interlace-color': 'rgba(255, 255, 255, 0.02)',
             '--font-family': "'Rajdhani', 'Share Tech Mono', monospace",
             '--button-font-size': '24px',
             '--upgrade-button-font-size': '16px',


### PR DESCRIPTION
### Motivation
- Make the theme label clearer by renaming the existing “Service HUD” theme to a more concise name.
- Improve legibility of top-line HUD elements (`Credits`, `Wave`, `Health`) which appeared faded under the CRT/fog styling.
- Reduce overlay/scanline intensity so HUD elements render visually in front rather than appearing desaturated.

### Description
- Renamed Theme 5 comment and `name` from `Service HUD` to `Neon` and `Neon HUD` in the `THEMES` array in `index.html`.
- Increased the theme HUD color by changing `--hud-color` to `#00ffe1` for higher contrast.
- Reduced CRT overlay strength by lowering `--crt-overlay-bg` alpha from `rgba(0,255,255,0.06)` to `rgba(0,255,255,0.03)`.
- Reduced scanline and interlace visibility by changing `--crt-scanline-color` and `--crt-interlace-color` from `rgba(255, 255, 255, 0.05)` to `rgba(255, 255, 255, 0.02)`.

### Testing
- Verified the resulting changes with `git diff -- index.html` and confirmed only Theme 5 entries were modified, success.
- Committed the change with a descriptive message via `git commit`, success.
- Inspected the updated lines with `nl -ba index.html` to confirm the `name` and CSS variable edits, success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1654bfe4c48322982330f23f06be2d)