### PR TITLE
Update enemy stats panel to refresh speed when wave-scaled enemies spawn

### DIFF
--- a/index.html
+++ b/index.html
@@ -1591,6 +1591,8 @@ function spawnEnemy(isBoss = false, waveNumber = gameState.wave) {
 
     if (enemyIntel.active && enemyIntel.known[enemy.type]) {
         enemyIntel.known[enemy.type].health = Math.round(health);
+        const knownSpeed = Number(enemyIntel.known[enemy.type].speed) || 0;
+        enemyIntel.known[enemy.type].speed = Math.max(knownSpeed, speed).toFixed(1);
         updateEnemyStatsPanel();
     }
     if (waveStates[waveNumber]) {


### PR DESCRIPTION
### Motivation
- The Enemy Stats panel showed stale speeds because identified enemy speed was kept from the first sighting and did not reflect wave-based scaling even though health was updated.

### Description
- In `index.html` inside `spawnEnemy`, update `enemyIntel.known[enemy.type].speed` by parsing the stored value and setting it to the maximum of the previously known speed and the current spawn `speed`, formatted to one decimal, while preserving the existing health update and calling `updateEnemyStatsPanel()`.

### Testing
- No automated test suite is present in the repository.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a165f49f630832296fb803bf74aefa5)