### PR TITLE
Embed Send Next Wave button into Battle Status panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -249,12 +249,18 @@
     display: inline-block;
   }
   #waveStatsBody { background: var(--hotkey-bg); padding: 5px 10px; border-radius: 5px; }
-  #waveStatsPanel.collapsed #waveStatsContent, #waveStatsPanel.collapsed #waveStatsTotal { display: none; }
+  #waveStatsPanel.collapsed #waveStatsContent, #waveStatsPanel.collapsed #waveStatsTotal, #waveStatsPanel.collapsed #sendWaveButton { display: none; }
   #waveStatsHeader { cursor: pointer; color: #fff; background: transparent; }
   #waveStatsHeader .arrow { margin-left: 4px; }
   .wave-divider-white { border-bottom:2px solid #fff; }
   .wave-divider-grey { border-bottom:1px solid #888; }
   .wave-total { color: var(--button-text); }
+  #waveStatsBody #sendWaveButton {
+    width: 100%;
+    margin-top: 8px;
+    font-size: var(--hotkey-font-size);
+    padding: 8px 10px;
+  }
   #hotkeys {
     word-wrap: break-word;
     max-width: 200px;
@@ -342,7 +348,6 @@
 
     <div id="musicControls"><button id="prevTrack">&#9664;</button><div id="trackDisplay">Off</div><button id="nextTrack">&#9654;</button><button id="sfxToggleButton">SFX: On</button><input id="musicVolume" type="range" min="0" max="1" step="0.01"></div>
 
-    <button id="sendWaveButton">Send Next Wave</button>
 </div>
 <div id="hotkeys" class="show">
   <div id="hotkeysHeader">Hotkeys <span id="hotkeysToggle" class="arrow">▾</span></div>
@@ -368,6 +373,7 @@
   <div id="waveStatsBody">
     <div id="waveStatsContent"></div>
     <div id="waveStatsTotal" class="wave-total"></div>
+    <button id="sendWaveButton">Send Next Wave</button>
   </div>
 </div>
 <div id="sensorWarning" style="display:none">


### PR DESCRIPTION
### Motivation
- Make the `Send Next Wave` control appear inside the same frame as the wave/totals so players can trigger the next wave from the Battle Status panel.

### Description
- Moved the `<button id="sendWaveButton">` from the bottom `#controls` bar into the `#waveStatsBody` inside the `#waveStatsPanel` so it sits with wave info and totals.
- Updated CSS so collapsing `#waveStatsPanel` hides the embedded button by adding `#waveStatsPanel.collapsed #sendWaveButton { display: none; }` and added panel-specific button styling (`#waveStatsBody #sendWaveButton`) for full-width/compact layout.
- No JavaScript event changes were required because the existing `#sendWaveButton` binding remains intact.

### Testing
- Ran repository verification and content checks with `rg`/`sed` to confirm the button was relocated and CSS updated, and the file was committed with `git commit`; these commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1662b2bd748322b814d8b445bd640c)