### PR TITLE
Sort enemy stats panel by ascending health

### DIFF
--- a/index.html
+++ b/index.html
@@ -4323,11 +4323,24 @@ function updateEnemyHUD(info) {
     if (sensorDisplayMode !== 'hud') return;
     // HUD mode no longer displays a popup since enemy stats panel replaces it
 }
+function getEnemyIntelDisplayOrder(){
+    const fallbackOrder={Fast:0,Normal:1,Tank:2,Boss:3,XP:4};
+    return Object.keys(enemyIntel.known).sort((a,b)=>{
+        const ah=Number(enemyIntel.known[a]?.health);
+        const bh=Number(enemyIntel.known[b]?.health);
+        const aFinite=Number.isFinite(ah);
+        const bFinite=Number.isFinite(bh);
+        if(aFinite&&bFinite&&ah!==bh) return ah-bh;
+        if(aFinite!==bFinite) return aFinite?-1:1;
+        return (fallbackOrder[a]??99)-(fallbackOrder[b]??99);
+    });
+}
+
 function updateEnemyStatsPanel(){
     const panel=getElement("enemyStatsPanel");
     const list=getElement("enemyStatsContent");
     let html="";
-    enemyIntel.order.forEach(t=>{
+    getEnemyIntelDisplayOrder().forEach(t=>{
         const d=enemyIntel.known[t];
         const hp=sensorUpgrades.showHealthBars?d.health:'?';
         html+=`<div>${t}: Spd ${d.speed} HP ${hp}</div>`;
@@ -4469,7 +4482,6 @@ function identifyEnemy(enemy){
     const baseStats={speed:enemy.speed.toFixed(1),health:Math.round(enemy.maxHealth),attack:"Unknown"};
     if(enemy.type==="XP"){baseStats.attack="Flees";}
     enemyIntel.known[enemy.type]=baseStats;
-    enemyIntel.order.push(enemy.type);
     pauseGame();
     showEnemyIntelPopup(enemy.type,enemyIntel.known[enemy.type]);
 }


### PR DESCRIPTION
### Motivation
- The Enemy Stats panel should present identified enemy types in order of increasing health so players always see the weakest (fast) first and the boss last once identified.
- Previously the panel rendered in discovery order which could show a non-deterministic ordering that doesn't reflect relative threat by health.

### Description
- Added `getEnemyIntelDisplayOrder()` which returns enemy types sorted by numeric `health` ascending and falls back to a deterministic ordering `Fast, Normal, Tank, Boss, XP` for ties or unknown values.
- Updated `updateEnemyStatsPanel()` to render using `getEnemyIntelDisplayOrder()` instead of relying on discovery order.
- Removed the now-unused `enemyIntel.order.push(...)` append in `identifyEnemy()` since ordering is computed at render time.

### Testing
- Performed code-level verification by inspecting the modified `index.html` and confirming the new helper is used from `updateEnemyStatsPanel()` and that `enemyIntel.order` is no longer appended. 
- Searched the repository for references to `enemyIntel.order` and `getEnemyIntelDisplayOrder` to confirm no unintended side effects. 
- No automated test suite exists in this repository, so verification was manual and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1666f4affc8322aec45cd0fe199449)